### PR TITLE
Add Favorite Lists management

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
             android:theme="@android:style/Theme.Light.NoTitleBar.Fullscreen"/>
         <activity android:name=".ui.LyricsViewerActivity"
             android:theme="@android:style/Theme.Light.NoTitleBar.Fullscreen"/>
+        <activity android:name=".ui.FavoriteListsActivity" />
         <service
             android:name=".audio.AudioPlayerService"
             android:foregroundServiceType="mediaPlayback"

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -5,10 +5,15 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 
-@Database(entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class], version = 11, exportSchema = false)
+@Database(
+    entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
+    version = 12,
+    exportSchema = false
+)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun songDao(): SongDao
     abstract fun appMetadataDao(): AppMetadataDao
+    abstract fun favoriteListDao(): FavoriteListDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteList.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteList.kt
@@ -1,0 +1,10 @@
+package de.jeisfeld.songarchive.db
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "favorite_lists")
+data class FavoriteList(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val name: String
+)

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListDao.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListDao.kt
@@ -1,0 +1,24 @@
+package de.jeisfeld.songarchive.db
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface FavoriteListDao {
+    @Query("SELECT * FROM favorite_lists ORDER BY id")
+    fun getAll(): Flow<List<FavoriteList>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(list: FavoriteList): Long
+
+    @Update
+    suspend fun update(list: FavoriteList)
+
+    @Delete
+    suspend fun delete(list: FavoriteList)
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListSong.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListSong.kt
@@ -1,0 +1,19 @@
+package de.jeisfeld.songarchive.db
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "favorite_list_song",
+    primaryKeys = ["listId", "songId"],
+    foreignKeys = [
+        ForeignKey(entity = FavoriteList::class, parentColumns = ["id"], childColumns = ["listId"], onDelete = ForeignKey.CASCADE),
+        ForeignKey(entity = Song::class, parentColumns = ["id"], childColumns = ["songId"], onDelete = ForeignKey.CASCADE)
+    ],
+    indices = [Index(value = ["listId"]), Index(value = ["songId"])]
+)
+data class FavoriteListSong(
+    val listId: Int,
+    val songId: String
+)

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListViewModel.kt
@@ -1,0 +1,31 @@
+package de.jeisfeld.songarchive.db
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class FavoriteListViewModel(application: Application) : AndroidViewModel(application) {
+    private val dao = AppDatabase.getDatabase(application).favoriteListDao()
+
+    val lists: StateFlow<List<FavoriteList>> = dao.getAll().stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = emptyList()
+    )
+
+    fun addList(name: String) {
+        viewModelScope.launch { dao.insert(FavoriteList(name = name)) }
+    }
+
+    fun rename(list: FavoriteList, newName: String) {
+        viewModelScope.launch { dao.update(list.copy(name = newName)) }
+    }
+
+    fun delete(list: FavoriteList) {
+        viewModelScope.launch { dao.delete(list) }
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/FavoriteListsActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/FavoriteListsActivity.kt
@@ -1,0 +1,16 @@
+package de.jeisfeld.songarchive.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.lifecycle.ViewModelProvider
+import de.jeisfeld.songarchive.db.FavoriteListViewModel
+import de.jeisfeld.songarchive.ui.theme.AppTheme
+
+class FavoriteListsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val viewModel = ViewModelProvider(this)[FavoriteListViewModel::class.java]
+        setContent { AppTheme { FavoriteListsScreen(viewModel) { finish() } } }
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/FavoriteListsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/FavoriteListsScreen.kt
@@ -1,0 +1,148 @@
+package de.jeisfeld.songarchive.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import de.jeisfeld.songarchive.R
+import de.jeisfeld.songarchive.db.FavoriteList
+import de.jeisfeld.songarchive.db.FavoriteListViewModel
+import de.jeisfeld.songarchive.ui.theme.AppColors
+
+@Composable
+fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
+    var showAdd by remember { mutableStateOf(false) }
+    var renameTarget by remember { mutableStateOf<FavoriteList?>(null) }
+    var deleteTarget by remember { mutableStateOf<FavoriteList?>(null) }
+
+    val lists by viewModel.lists.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(id = R.string.favorite_lists)) },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = AppColors.Background,
+                    titleContentColor = AppColors.TextColor
+                ),
+                navigationIcon = {
+                    IconButton(onClick = onClose) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_close),
+                            contentDescription = "Close",
+                            tint = AppColors.TextColor,
+                            modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small))
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { showAdd = true }) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_add),
+                            contentDescription = stringResource(id = R.string.add_favorite_list),
+                            tint = AppColors.TextColor,
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = dimensionResource(id = R.dimen.spacing_medium))
+        ) {
+            LazyColumn(modifier = Modifier.fillMaxSize()) {
+                items(lists) { list ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = dimensionResource(id = R.dimen.spacing_small)),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(text = list.name, color = AppColors.TextColor, modifier = Modifier.weight(1f))
+                        IconButton(onClick = { renameTarget = list }) {
+                            Icon(painter = painterResource(id = R.drawable.ic_edit), contentDescription = stringResource(id = R.string.rename_favorite_list))
+                        }
+                        IconButton(onClick = { deleteTarget = list }) {
+                            Icon(painter = painterResource(id = R.drawable.ic_delete), contentDescription = stringResource(id = R.string.delete_favorite_list))
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAdd) {
+        var name by remember { mutableStateOf("") }
+        AlertDialog(
+            onDismissRequest = { showAdd = false },
+            title = { Text(stringResource(id = R.string.add_favorite_list)) },
+            text = { OutlinedTextField(value = name, onValueChange = { name = it }, placeholder = { Text(stringResource(id = R.string.list_name)) }) },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (name.isNotBlank()) viewModel.addList(name)
+                    showAdd = false
+                }) { Text(stringResource(id = R.string.ok)) }
+            },
+            dismissButton = { TextButton(onClick = { showAdd = false }) { Text(stringResource(id = R.string.cancel)) } }
+        )
+    }
+
+    renameTarget?.let { list ->
+        var name by remember { mutableStateOf(list.name) }
+        AlertDialog(
+            onDismissRequest = { renameTarget = null },
+            title = { Text(stringResource(id = R.string.rename_favorite_list)) },
+            text = { OutlinedTextField(value = name, onValueChange = { name = it }) },
+            confirmButton = {
+                TextButton(onClick = {
+                    if (name.isNotBlank()) viewModel.rename(list, name)
+                    renameTarget = null
+                }) { Text(stringResource(id = R.string.ok)) }
+            },
+            dismissButton = { TextButton(onClick = { renameTarget = null }) { Text(stringResource(id = R.string.cancel)) } }
+        )
+    }
+
+    deleteTarget?.let { list ->
+        AlertDialog(
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(stringResource(id = R.string.delete_favorite_list)) },
+            text = { Text(stringResource(id = R.string.confirm_delete_list)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.delete(list)
+                    deleteTarget = null
+                }) { Text(stringResource(id = R.string.ok)) }
+            },
+            dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text(stringResource(id = R.string.cancel)) } }
+        )
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
@@ -1,0 +1,176 @@
+package de.jeisfeld.songarchive.ui
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.compose.foundation.background
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat
+import de.jeisfeld.songarchive.R
+import de.jeisfeld.songarchive.network.PeerConnectionMode
+import de.jeisfeld.songarchive.network.PeerConnectionViewModel
+import de.jeisfeld.songarchive.network.isNearbyConnectionPossible
+import de.jeisfeld.songarchive.ui.theme.AppColors
+import de.jeisfeld.songarchive.ui.FavoriteListsActivity
+
+@Composable
+fun MainDropdownMenu(
+    showMenu: Boolean,
+    onDismissRequest: () -> Unit,
+    context: Context,
+    permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>,
+    onShareText: () -> Unit,
+    onSync: () -> Unit,
+) {
+    var showNetworkDialog by remember { mutableStateOf(false) }
+
+    DropdownMenu(
+        expanded = showMenu,
+        onDismissRequest = onDismissRequest,
+        modifier = Modifier.background(AppColors.BackgroundShaded)
+    ) {
+        DropdownMenuItem(
+            text = {
+                Text(
+                    stringResource(id = R.string.sync),
+                    color = AppColors.TextColor
+                )
+            },
+            onClick = {
+                onDismissRequest()
+                onSync()
+            },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_sync),
+                    contentDescription = "Sync",
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                )
+            }
+        )
+        if (isNearbyConnectionPossible(context)) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        stringResource(id = R.string.network_connection),
+                        color = AppColors.TextColor
+                    )
+                },
+                onClick = {
+                    showNetworkDialog = true
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_wifi),
+                        contentDescription = "Wi-Fi Transfer",
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                    )
+                }
+            )
+        }
+        DropdownMenuItem(
+            text = {
+                Text(
+                    stringResource(id = R.string.favorite_lists),
+                    color = AppColors.TextColor
+                )
+            },
+            onClick = {
+                onDismissRequest()
+                context.startActivity(android.content.Intent(context, FavoriteListsActivity::class.java))
+            },
+            leadingIcon = {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_list),
+                    contentDescription = stringResource(id = R.string.favorite_lists),
+                    modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                )
+            }
+        )
+        if (showNetworkDialog) {
+            NetworkModeDialog(
+                context = context,
+                selectedNetworkMode = PeerConnectionViewModel.peerConnectionMode,
+                selectedClientMode = PeerConnectionViewModel.clientMode,
+                onModeSelected = { networkMode, clientMode ->
+                    val isPeerConnectionModeChanged = networkMode != PeerConnectionViewModel.peerConnectionMode
+                    PeerConnectionViewModel.peerConnectionMode = networkMode
+                    PeerConnectionViewModel.clientMode = clientMode
+                    onDismissRequest()
+                    showNetworkDialog = false
+                    val requiredPermissions = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                        arrayOf(
+                            Manifest.permission.NEARBY_WIFI_DEVICES,
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.BLUETOOTH,
+                            Manifest.permission.BLUETOOTH_SCAN,
+                            Manifest.permission.BLUETOOTH_ADMIN,
+                            Manifest.permission.BLUETOOTH_CONNECT,
+                            Manifest.permission.BLUETOOTH_ADVERTISE
+                        )
+                    } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                        arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.BLUETOOTH,
+                            Manifest.permission.BLUETOOTH_SCAN,
+                            Manifest.permission.BLUETOOTH_ADMIN,
+                            Manifest.permission.BLUETOOTH_CONNECT,
+                            Manifest.permission.BLUETOOTH_ADVERTISE
+                        )
+                    } else {
+                        arrayOf(
+                            Manifest.permission.ACCESS_FINE_LOCATION,
+                            Manifest.permission.BLUETOOTH,
+                            Manifest.permission.BLUETOOTH_ADMIN,
+                        )
+                    }
+                    val missingPermissions = requiredPermissions.filter {
+                        ContextCompat.checkSelfPermission(context, it) != android.content.pm.PackageManager.PERMISSION_GRANTED
+                    }
+                    if (isPeerConnectionModeChanged) {
+                        if (missingPermissions.isNotEmpty()) {
+                            permissionLauncher.launch(missingPermissions.toTypedArray())
+                        } else {
+                            PeerConnectionViewModel.startPeerConnectionService(context)
+                        }
+                    }
+                },
+                onDismiss = { showNetworkDialog = false }
+            )
+        }
+        if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER && PeerConnectionViewModel.connectedDevices > 0) {
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        stringResource(id = R.string.share_text),
+                        color = AppColors.TextColor
+                    )
+                },
+                onClick = {
+                    onDismissRequest()
+                    onShareText()
+                },
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_send),
+                        contentDescription = "Send Lyrics",
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                    )
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/textColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M19,13H13v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_delete.xml
+++ b/app/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/textColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M6,19A2,2 0 0,0 8,21h8a2,2 0 0,0 2-2V7H6v12M19,4h-3.5l-1-1h-5l-1,1H5v2h14V4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_edit.xml
+++ b/app/src/main/res/drawable/ic_edit.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/textColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M3,17.25V21h3.75L17.81,9.94l-3.75-3.75L3,17.25zM20.71,7.04c0.39,-0.39 0.39,-1.02 0,-1.41l-2.34,-2.34c-0.39,-0.39 -1.02,-0.39 -1.41,0l-1.83,1.83 3.75,3.75 1.83,-1.83z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_list.xml
+++ b/app/src/main/res/drawable/ic_list.xml
@@ -1,0 +1,3 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="@color/textColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/white" android:pathData="M3,13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zm0-10v2h14V7H7z"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -45,6 +45,14 @@
     <string name="notification_client_disconnected">Als Empfänger getrennt</string>
     <string name="notification_unknown">Unbekannter Status (%d Verbindungen)</string>
 
+    <!-- Favorite Lists -->
+    <string name="favorite_lists">Favoritenlisten</string>
+    <string name="add_favorite_list">Favoritenliste hinzufügen</string>
+    <string name="rename_favorite_list">Favoritenliste umbenennen</string>
+    <string name="delete_favorite_list">Favoritenliste löschen</string>
+    <string name="confirm_delete_list">Favoritenliste wirklich löschen?</string>
+    <string name="list_name">Listenname</string>
+
     <string-array name="network_modes">
         <item>Deaktiviert</item>
         <item>Sender</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,14 @@
     <string name="notification_client_disconnected">Disconnected as client</string>
     <string name="notification_unknown">Unknown status (%d connections)</string>
 
+    <!-- Favorite Lists -->
+    <string name="favorite_lists">Favorite Lists</string>
+    <string name="add_favorite_list">Add Favorite List</string>
+    <string name="rename_favorite_list">Rename Favorite List</string>
+    <string name="delete_favorite_list">Delete Favorite List</string>
+    <string name="confirm_delete_list">Delete this list?</string>
+    <string name="list_name">List name</string>
+
     <string-array name="network_modes">
         <item>Disabled</item>
         <item>Server</item>


### PR DESCRIPTION
## Summary
- bump DB version and add FavoriteList tables
- include FavoriteListsActivity in manifest and menu
- implement FavoriteListViewModel and new composables for managing lists
- add vector icons and strings for Favorite List actions

## Testing
- `./gradlew test` *(fails: Permission denied / proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6884c697f4a88322b34678d0d44632af