### PR TITLE
Fix action column alignment and restore list row spacing

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/SongTable.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/SongTable.kt
@@ -106,9 +106,19 @@ fun SongTable(
                     color = AppColors.TextColor
                 )
             }
+            val iconSize = dimensionResource(id = R.dimen.icon_size_small)
+            val spacing = dimensionResource(id = R.dimen.spacing_medium)
+            val actionsWidth = dimensionResource(id = R.dimen.width_actions)
+            val paddingStart = if (onRemoveFromList != null || onAddToList != null) {
+                0.dp
+            } else {
+                actionsWidth - iconSize * 3 - spacing * 2
+            }
             Text(
                 text = stringResource(id = R.string.column_actions),
-                modifier = Modifier.width(dimensionResource(id = R.dimen.width_actions)),
+                modifier = Modifier
+                    .width(actionsWidth)
+                    .padding(start = paddingStart),
                 fontWeight = FontWeight.Bold,
                 color = AppColors.TextColor
             )

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsScreen.kt
@@ -97,7 +97,7 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = dimensionResource(id = R.dimen.spacing_small))
+                            .padding(vertical = dimensionResource(id = R.dimen.spacing_medium))
                             .clickable {
                                 val intent = Intent(context, FavoriteListSongsActivity::class.java).apply {
                                     putExtra("LIST_ID", list.id)
@@ -106,12 +106,16 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
                                 context.startActivity(intent)
                             },
                         verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween
+                        horizontalArrangement = Arrangement.spacedBy(
+                            dimensionResource(id = R.dimen.spacing_medium),
+                            Alignment.End
+                        )
                     ) {
                         Text(text = list.name, color = AppColors.TextColor, modifier = Modifier.weight(1f))
                         if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER &&
                             PeerConnectionViewModel.connectedDevices > 0) {
-                            IconButton(onClick = {
+                            IconButton(
+                                onClick = {
                                 scope.launch {
                                     val songs = withContext(Dispatchers.IO) { viewModel.getSongsForList(list.id) }
                                     val ids = songs.joinToString(",") { it.id }
@@ -123,14 +127,22 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
                                     }
                                     context.startService(intent)
                                 }
-                            }) {
+                            },
+                                modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                            ) {
                                 Image(painter = painterResource(id = R.drawable.ic_send), contentDescription = stringResource(id = R.string.share_favorite_list))
                             }
                         }
-                        IconButton(onClick = { renameTarget = list }) {
+                        IconButton(
+                            onClick = { renameTarget = list },
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                        ) {
                             Image(painter = painterResource(id = R.drawable.ic_edit), contentDescription = stringResource(id = R.string.rename_favorite_list))
                         }
-                        IconButton(onClick = { deleteTarget = list }) {
+                        IconButton(
+                            onClick = { deleteTarget = list },
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                        ) {
                             Image(painter = painterResource(id = R.drawable.ic_delete), contentDescription = stringResource(id = R.string.delete_favorite_list))
                         }
                     }


### PR DESCRIPTION
## Summary
- adjust padding so the "Aktionen" header stays left-aligned whether three or four action icons are shown
- increase vertical padding for favorite-list rows to restore the previous spacing

## Testing
- `./gradlew --version` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68874a3c76708322a25f5afa147a3bac