### PR TITLE
Fix icon spacing on tablets

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/SongTable.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/SongTable.kt
@@ -90,7 +90,7 @@ fun SongTable(
         val actionsWidth = if (onRemoveFromList != null || onAddToList != null) {
             baseActionsWidth
         } else {
-            baseActionsWidth - iconSize - spacing
+            baseActionsWidth - iconSize - spacing * 2
         }
         // Fixed Table Header (Outside LazyColumn)
         Row(modifier = Modifier.fillMaxWidth().padding(bottom = dimensionResource(id = R.dimen.spacing_small))) {
@@ -159,7 +159,10 @@ fun SongTable(
                         }
                         Row(
                             modifier = Modifier.width(actionsWidth),
-                            horizontalArrangement = Arrangement.End
+                            horizontalArrangement = Arrangement.spacedBy(
+                                dimensionResource(id = R.dimen.spacing_medium),
+                                Alignment.End
+                            )
                         ) {
                             if (onRemoveFromList != null && removableIds.contains(song.id)) {
                                 Image(
@@ -169,7 +172,6 @@ fun SongTable(
                                         onRemoveFromList(song)
                                     }
                                 )
-                                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                             } else if (onAddToList != null && addableIds.contains(song.id)) {
                                 Image(
                                     painter = painterResource(id = R.drawable.ic_add),
@@ -178,7 +180,6 @@ fun SongTable(
                                         onAddToList(song)
                                     }
                                 )
-                                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                             }
                             Image(
                                 painter = painterResource(id = R.drawable.text2),
@@ -189,7 +190,6 @@ fun SongTable(
                                     context.startActivity(intent)
                                 }
                             )
-                            Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
 
                             song.tabfilename?.takeIf { it.isNotBlank() }?.let {
                                 Image(
@@ -211,7 +211,6 @@ fun SongTable(
                                         }
                                     }
                                 )
-                                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                             }
 
                             song.mp3filename?.takeIf { it.isNotBlank() && isConnected }?.let { filename ->

--- a/app/src/main/res/values-land/dimens.xml
+++ b/app/src/main/res/values-land/dimens.xml
@@ -2,5 +2,5 @@
 <resources>
     <dimen name="spacing_medium">10dp</dimen>
     <dimen name="spacing_heading_vertical">8dp</dimen>
-    <dimen name="width_actions">126dp</dimen>
+    <dimen name="width_actions">136dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw450dp/dimens.xml
+++ b/app/src/main/res/values-sw450dp/dimens.xml
@@ -9,5 +9,5 @@
     <dimen name="icon_size_large">44dp</dimen>
     <dimen name="icon_font_large">22sp</dimen>
     <dimen name="width_id">58dp</dimen>
-    <dimen name="width_actions">136dp</dimen>
+    <dimen name="width_actions">144dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp-land/dimens.xml
+++ b/app/src/main/res/values-sw600dp-land/dimens.xml
@@ -3,5 +3,5 @@
     <dimen name="spacing_medium">24dp</dimen>
     <dimen name="spacing_search_vertical">4dp</dimen>
     <dimen name="spacing_heading_vertical">16dp</dimen>
-    <dimen name="width_actions">208dp</dimen>
+    <dimen name="width_actions">232dp</dimen>
 </resources>

--- a/app/src/main/res/values-sw600dp/dimens.xml
+++ b/app/src/main/res/values-sw600dp/dimens.xml
@@ -9,5 +9,5 @@
     <dimen name="icon_size_large">50dp</dimen>
     <dimen name="icon_font_large">25sp</dimen>
     <dimen name="width_id">66dp</dimen>
-    <dimen name="width_actions">172dp</dimen>
+    <dimen name="width_actions">184dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -9,5 +9,5 @@
     <dimen name="icon_size_large">40dp</dimen>
     <dimen name="icon_font_large">20sp</dimen>
     <dimen name="width_id">50dp</dimen>
-    <dimen name="width_actions">120dp</dimen>
+    <dimen name="width_actions">128dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- expand actions column width across device configs
- adjust width logic in SongTable to maintain icon size when 4 icons are shown

## Testing
- `./gradlew test --console=plain` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68879d0185dc832291e1b22da86230f1