### PR TITLE
Improve network dialog styling

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeDialog.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeDialog.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -34,6 +35,7 @@ import androidx.compose.ui.window.Dialog
 import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.network.ClientMode
 import de.jeisfeld.songarchive.network.PeerConnectionMode
+import de.jeisfeld.songarchive.ui.theme.AppColors
 
 @Composable
 fun NetworkModeDialog(
@@ -51,12 +53,14 @@ fun NetworkModeDialog(
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = RoundedCornerShape(8.dp),
-            tonalElevation = 4.dp
+            tonalElevation = 4.dp,
+            color = AppColors.BackgroundShaded
         ) {
             Column(modifier = Modifier.padding(24.dp)) {
                 Text(
                     text = stringResource(R.string.network_mode),
-                    style = MaterialTheme.typography.headlineSmall
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = AppColors.TextColor
                 )
 
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
@@ -71,11 +75,16 @@ fun NetworkModeDialog(
                     ) {
                         RadioButton(
                             selected = (selectedNetworkOption == option),
-                            onClick = { selectedNetworkOption = option }
+                            onClick = { selectedNetworkOption = option },
+                            colors = RadioButtonDefaults.colors(
+                                selectedColor = AppColors.TextColor,
+                                unselectedColor = AppColors.TextColorLight
+                            )
                         )
                         Text(
                             text = stringArrayResource(R.array.network_modes)[index],
-                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                            color = AppColors.TextColor
                         )
                     }
                 }
@@ -85,7 +94,8 @@ fun NetworkModeDialog(
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_medium)))
                     Text(
                         text = stringResource(R.string.client_type),
-                        style = MaterialTheme.typography.titleMedium
+                        style = MaterialTheme.typography.titleMedium,
+                        color = AppColors.TextColor
                     )
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
 
@@ -98,11 +108,16 @@ fun NetworkModeDialog(
                         ) {
                             RadioButton(
                                 selected = (selectedClientOption == option),
-                                onClick = { selectedClientOption = option }
+                                onClick = { selectedClientOption = option },
+                                colors = RadioButtonDefaults.colors(
+                                    selectedColor = AppColors.TextColor,
+                                    unselectedColor = AppColors.TextColorLight
+                                )
                             )
                             Text(
                                 text = stringArrayResource(R.array.client_modes)[index],
-                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                                color = AppColors.TextColor
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- integrate AppColors in `NetworkModeDialog`
- use radio button and text colors from the theme

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888af8725648322b0a6e744c9ebef74