### PR TITLE
Use dropdown menu for network settings

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
@@ -23,6 +23,7 @@ import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.network.PeerConnectionMode
 import de.jeisfeld.songarchive.network.PeerConnectionViewModel
 import de.jeisfeld.songarchive.network.isNearbyConnectionPossible
+import de.jeisfeld.songarchive.ui.NetworkModeMenu
 import de.jeisfeld.songarchive.ui.theme.AppColors
 import de.jeisfeld.songarchive.ui.favoritelists.FavoriteListsActivity
 import de.jeisfeld.songarchive.ui.settings.SettingsActivity
@@ -36,7 +37,7 @@ fun MainDropdownMenu(
     onShareText: () -> Unit,
     onSync: () -> Unit,
 ) {
-    var showNetworkDialog by remember { mutableStateOf(false) }
+    var showNetworkMenu by remember { mutableStateOf(false) }
 
     DropdownMenu(
         expanded = showMenu,
@@ -109,7 +110,7 @@ fun MainDropdownMenu(
                     )
                 },
                 onClick = {
-                    showNetworkDialog = true
+                    showNetworkMenu = true
                 },
                 leadingIcon = {
                     Icon(
@@ -120,8 +121,9 @@ fun MainDropdownMenu(
                 }
             )
         }
-        if (showNetworkDialog) {
-            NetworkModeDialog(
+        if (showNetworkMenu) {
+            NetworkModeMenu(
+                expanded = true,
                 context = context,
                 selectedNetworkMode = PeerConnectionViewModel.peerConnectionMode,
                 selectedClientMode = PeerConnectionViewModel.clientMode,
@@ -130,7 +132,7 @@ fun MainDropdownMenu(
                     PeerConnectionViewModel.peerConnectionMode = networkMode
                     PeerConnectionViewModel.clientMode = clientMode
                     onDismissRequest()
-                    showNetworkDialog = false
+                    showNetworkMenu = false
                     val requiredPermissions = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                         arrayOf(
                             Manifest.permission.NEARBY_WIFI_DEVICES,
@@ -168,7 +170,7 @@ fun MainDropdownMenu(
                         }
                     }
                 },
-                onDismiss = { showNetworkDialog = false }
+                onDismiss = { showNetworkMenu = false }
             )
         }
         if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER && PeerConnectionViewModel.connectedDevices > 0) {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeMenu.kt
@@ -1,8 +1,6 @@
 package de.jeisfeld.songarchive.ui
 
 import android.content.Context
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,9 +11,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -29,14 +29,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.network.ClientMode
 import de.jeisfeld.songarchive.network.PeerConnectionMode
+import de.jeisfeld.songarchive.ui.theme.AppColors
 
 @Composable
-fun NetworkModeDialog(
+fun NetworkModeMenu(
+    expanded: Boolean,
     context: Context,
     selectedNetworkMode: PeerConnectionMode,
     selectedClientMode: ClientMode,
@@ -48,15 +50,24 @@ fun NetworkModeDialog(
     val clientOptions = listOf(ClientMode.LYRICS_BS, ClientMode.LYRICS_BW, ClientMode.LYRICS_WB, ClientMode.CHORDS)
     var selectedClientOption by remember { mutableStateOf(selectedClientMode) }
 
-    Dialog(onDismissRequest = onDismiss) {
+    val widthActions = dimensionResource(R.dimen.width_actions)
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        offset = DpOffset(widthActions, 0.dp),
+        modifier = Modifier.background(AppColors.BackgroundShaded)
+    ) {
         Surface(
             shape = RoundedCornerShape(8.dp),
-            tonalElevation = 4.dp
+            tonalElevation = 4.dp,
+            color = AppColors.BackgroundShaded
         ) {
             Column(modifier = Modifier.padding(24.dp)) {
                 Text(
                     text = stringResource(R.string.network_mode),
-                    style = MaterialTheme.typography.headlineSmall
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = AppColors.TextColor
                 )
 
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
@@ -71,11 +82,16 @@ fun NetworkModeDialog(
                     ) {
                         RadioButton(
                             selected = (selectedNetworkOption == option),
-                            onClick = { selectedNetworkOption = option }
+                            onClick = { selectedNetworkOption = option },
+                            colors = RadioButtonDefaults.colors(
+                                selectedColor = AppColors.TextColor,
+                                unselectedColor = AppColors.TextColorLight
+                            )
                         )
                         Text(
                             text = stringArrayResource(R.array.network_modes)[index],
-                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                            color = AppColors.TextColor
                         )
                     }
                 }
@@ -85,7 +101,8 @@ fun NetworkModeDialog(
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_medium)))
                     Text(
                         text = stringResource(R.string.client_type),
-                        style = MaterialTheme.typography.titleMedium
+                        style = MaterialTheme.typography.titleMedium,
+                        color = AppColors.TextColor
                     )
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
 
@@ -98,11 +115,16 @@ fun NetworkModeDialog(
                         ) {
                             RadioButton(
                                 selected = (selectedClientOption == option),
-                                onClick = { selectedClientOption = option }
+                                onClick = { selectedClientOption = option },
+                                colors = RadioButtonDefaults.colors(
+                                    selectedColor = AppColors.TextColor,
+                                    unselectedColor = AppColors.TextColorLight
+                                )
                             )
                             Text(
                                 text = stringArrayResource(R.array.client_modes)[index],
-                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                                color = AppColors.TextColor
                             )
                         }
                     }


### PR DESCRIPTION
## Summary
- switch `NetworkModeDialog` to `NetworkModeMenu` implemented with a `DropdownMenu`
- open network settings submenu from `MainDropdownMenu`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888af8725648322b0a6e744c9ebef74