### PR TITLE
Use dropdown menu for network settings

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
@@ -23,6 +23,7 @@ import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.network.PeerConnectionMode
 import de.jeisfeld.songarchive.network.PeerConnectionViewModel
 import de.jeisfeld.songarchive.network.isNearbyConnectionPossible
+import de.jeisfeld.songarchive.ui.NetworkModeMenu
 import de.jeisfeld.songarchive.ui.theme.AppColors
 import de.jeisfeld.songarchive.ui.favoritelists.FavoriteListsActivity
 import de.jeisfeld.songarchive.ui.settings.SettingsActivity
@@ -36,7 +37,7 @@ fun MainDropdownMenu(
     onShareText: () -> Unit,
     onSync: () -> Unit,
 ) {
-    var showNetworkDialog by remember { mutableStateOf(false) }
+    var showNetworkMenu by remember { mutableStateOf(false) }
 
     DropdownMenu(
         expanded = showMenu,
@@ -109,7 +110,7 @@ fun MainDropdownMenu(
                     )
                 },
                 onClick = {
-                    showNetworkDialog = true
+                    showNetworkMenu = true
                 },
                 leadingIcon = {
                     Icon(
@@ -120,8 +121,9 @@ fun MainDropdownMenu(
                 }
             )
         }
-        if (showNetworkDialog) {
-            NetworkModeDialog(
+        if (showNetworkMenu) {
+            NetworkModeMenu(
+                expanded = true,
                 context = context,
                 selectedNetworkMode = PeerConnectionViewModel.peerConnectionMode,
                 selectedClientMode = PeerConnectionViewModel.clientMode,
@@ -130,7 +132,7 @@ fun MainDropdownMenu(
                     PeerConnectionViewModel.peerConnectionMode = networkMode
                     PeerConnectionViewModel.clientMode = clientMode
                     onDismissRequest()
-                    showNetworkDialog = false
+                    showNetworkMenu = false
                     val requiredPermissions = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
                         arrayOf(
                             Manifest.permission.NEARBY_WIFI_DEVICES,
@@ -168,7 +170,7 @@ fun MainDropdownMenu(
                         }
                     }
                 },
-                onDismiss = { showNetworkDialog = false }
+                onDismiss = { showNetworkMenu = false }
             )
         }
         if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER && PeerConnectionViewModel.connectedDevices > 0) {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/NetworkModeMenu.kt
@@ -1,8 +1,6 @@
 package de.jeisfeld.songarchive.ui
 
 import android.content.Context
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -13,9 +11,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -26,17 +26,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.window.Dialog
 import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.network.ClientMode
 import de.jeisfeld.songarchive.network.PeerConnectionMode
+import de.jeisfeld.songarchive.ui.theme.AppColors
 
 @Composable
-fun NetworkModeDialog(
+fun NetworkModeMenu(
+    expanded: Boolean,
     context: Context,
     selectedNetworkMode: PeerConnectionMode,
     selectedClientMode: ClientMode,
@@ -48,15 +51,32 @@ fun NetworkModeDialog(
     val clientOptions = listOf(ClientMode.LYRICS_BS, ClientMode.LYRICS_BW, ClientMode.LYRICS_WB, ClientMode.CHORDS)
     var selectedClientOption by remember { mutableStateOf(selectedClientMode) }
 
-    Dialog(onDismissRequest = onDismiss) {
+    val widthActions = dimensionResource(R.dimen.width_actions)
+    val minHeight = dimensionResource(R.dimen.network_menu_min_height)
+    val verticalOffset = dimensionResource(R.dimen.network_menu_vertical_offset)
+    val rightMargin = dimensionResource(R.dimen.spacing_small)
+    val screenWidth = LocalConfiguration.current.screenWidthDp.dp
+
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = onDismiss,
+        offset = DpOffset(screenWidth - widthActions - rightMargin, verticalOffset),
+        modifier = Modifier.background(AppColors.BackgroundShaded)
+    ) {
         Surface(
             shape = RoundedCornerShape(8.dp),
-            tonalElevation = 4.dp
+            tonalElevation = 4.dp,
+            color = AppColors.BackgroundShaded
         ) {
-            Column(modifier = Modifier.padding(24.dp)) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .heightIn(min = minHeight)
+            ) {
                 Text(
                     text = stringResource(R.string.network_mode),
-                    style = MaterialTheme.typography.headlineSmall
+                    style = MaterialTheme.typography.headlineSmall,
+                    color = AppColors.TextColor
                 )
 
                 Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
@@ -71,11 +91,16 @@ fun NetworkModeDialog(
                     ) {
                         RadioButton(
                             selected = (selectedNetworkOption == option),
-                            onClick = { selectedNetworkOption = option }
+                            onClick = { selectedNetworkOption = option },
+                            colors = RadioButtonDefaults.colors(
+                                selectedColor = AppColors.TextColor,
+                                unselectedColor = AppColors.TextColorLight
+                            )
                         )
                         Text(
                             text = stringArrayResource(R.array.network_modes)[index],
-                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                            modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                            color = AppColors.TextColor
                         )
                     }
                 }
@@ -85,7 +110,8 @@ fun NetworkModeDialog(
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_medium)))
                     Text(
                         text = stringResource(R.string.client_type),
-                        style = MaterialTheme.typography.titleMedium
+                        style = MaterialTheme.typography.titleMedium,
+                        color = AppColors.TextColor
                     )
                     Spacer(modifier = Modifier.height(dimensionResource(R.dimen.spacing_small)))
 
@@ -98,11 +124,16 @@ fun NetworkModeDialog(
                         ) {
                             RadioButton(
                                 selected = (selectedClientOption == option),
-                                onClick = { selectedClientOption = option }
+                                onClick = { selectedClientOption = option },
+                                colors = RadioButtonDefaults.colors(
+                                    selectedColor = AppColors.TextColor,
+                                    unselectedColor = AppColors.TextColorLight
+                                )
                             )
                             Text(
                                 text = stringArrayResource(R.array.client_modes)[index],
-                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium))
+                                modifier = Modifier.padding(start = dimensionResource(R.dimen.spacing_medium)),
+                                color = AppColors.TextColor
                             )
                         }
                     }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,4 +11,6 @@
     <dimen name="icon_font_large">20sp</dimen>
     <dimen name="width_id">50dp</dimen>
     <dimen name="width_actions">128dp</dimen>
+    <dimen name="network_menu_min_height">300dp</dimen>
+    <dimen name="network_menu_vertical_offset">-144dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- switch `NetworkModeDialog` to `NetworkModeMenu` implemented with a `DropdownMenu`
- open network settings submenu from `MainDropdownMenu`
- fix submenu alignment and height
- adjust network submenu position
- fix horizontal submenu alignment

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `./gradlew lint` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888af8725648322b0a6e744c9ebef74