### PR TITLE
Add language selection setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.appcompat)
 
     // Jetpack Compose UI
     implementation(libs.ui)

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -4,16 +4,28 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun songDao(): SongDao
     abstract fun appMetadataDao(): AppMetadataDao
     abstract fun favoriteListDao(): FavoriteListDao
+
+    private object Migrations {
+        val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE app_metadata ADD COLUMN app_language TEXT NOT NULL DEFAULT 'system'"
+                )
+            }
+        }
+    }
 
     companion object {
         @Volatile
@@ -26,7 +38,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "songs.db"
                 )
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(Migrations.MIGRATION_12_13)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
@@ -7,5 +7,6 @@ import androidx.room.PrimaryKey
 data class AppMetadata(
     @PrimaryKey val id: Int = 1,  // Always only one row
     val numberOfTabs: Int,
-    val chordsZipSize: Long
+    val chordsZipSize: Long,
+    val appLanguage: String = "system"
 )

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsActivity.kt
@@ -3,11 +3,14 @@ package de.jeisfeld.songarchive.ui.settings
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.ViewModelProvider
 import de.jeisfeld.songarchive.ui.theme.AppTheme
+import de.jeisfeld.songarchive.db.SongViewModel
 
 class SettingsActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { AppTheme { SettingsScreen { finish() } } }
+        val viewModel = ViewModelProvider(this)[SongViewModel::class.java]
+        setContent { AppTheme { SettingsScreen(viewModel) { finish() } } }
     }
 }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
@@ -4,30 +4,32 @@ import android.content.Intent
 import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import de.jeisfeld.songarchive.R
+import de.jeisfeld.songarchive.db.SongViewModel
 import de.jeisfeld.songarchive.ui.theme.AppColors
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(onClose: () -> Unit) {
+fun SettingsScreen(viewModel: SongViewModel, onClose: () -> Unit) {
     val context = LocalContext.current
     Scaffold(
         topBar = {
@@ -60,6 +62,42 @@ fun SettingsScreen(onClose: () -> Unit) {
                 text = stringResource(id = R.string.settings),
                 style = MaterialTheme.typography.headlineSmall
             )
+            Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
+            Text(
+                text = stringResource(id = R.string.app_language),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacing_small)))
+            val lang = viewModel.appLanguage.value
+            val options = listOf("system", "en", "de")
+            val labels = listOf(
+                R.string.language_system,
+                R.string.language_english,
+                R.string.language_german
+            )
+            options.forEachIndexed { index, option ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { viewModel.setAppLanguage(option) }
+                        .padding(vertical = dimensionResource(id = R.dimen.spacing_vertical_small))
+                ) {
+                    RadioButton(
+                        selected = lang == option,
+                        onClick = { viewModel.setAppLanguage(option) },
+                        colors = RadioButtonDefaults.colors(
+                            selectedColor = AppColors.TextColor,
+                            unselectedColor = AppColors.TextColorLight
+                        )
+                    )
+                    Text(
+                        text = stringResource(id = labels[index]),
+                        modifier = Modifier.padding(start = dimensionResource(id = R.dimen.spacing_medium)),
+                        color = AppColors.TextColor
+                    )
+                }
+            }
             Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
             TextButton(onClick = {
                 val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,4 +74,8 @@
         <item>Texte (weiß/schwarz)</item>
         <item>Akkorde</item>
     </string-array>
+    <string name="app_language">App-Sprache</string>
+    <string name="language_system">System</string>
+    <string name="language_english">Englisch</string>
+    <string name="language_german">Deutsch</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,4 +74,8 @@
         <item>Lyrics (white/black)</item>
         <item>Chords</item>
     </string-array>
+    <string name="app_language">App Language</string>
+    <string name="language_system">System</string>
+    <string name="language_english">English</string>
+    <string name="language_german">German</string>
 </resources>


### PR DESCRIPTION
## Summary
- make `AppCompat` available in the main app
- add `appLanguage` column to `AppMetadata`
- create migration to preserve data
- provide `SongViewModel` helpers to load and change language
- allow choosing app language in the settings screen
- update translations

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888c813f39c832291a436bc6692fe05