### PR TITLE
Add App language setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
+    implementation(libs.androidx.appcompat)
 
     // Jetpack Compose UI
     implementation(libs.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
     <uses-permission android:name="de.jeisfeld.songarchive.PERMISSION_COMMUNICATE" />
 
     <application
+        android:name="de.jeisfeld.songarchive.SongArchiveApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -44,9 +45,9 @@
         </activity>
         <activity android:name=".ui.ChordsViewerActivity"
             android:screenOrientation="userLandscape"
-            android:theme="@android:style/Theme.Light.NoTitleBar.Fullscreen"/>
+            android:theme="@style/Theme.CircleSongArchive"/>
         <activity android:name=".ui.LyricsViewerActivity"
-            android:theme="@android:style/Theme.Light.NoTitleBar.Fullscreen"/>
+            android:theme="@style/Theme.CircleSongArchive"/>
         <activity android:name=".ui.favoritelists.FavoriteListsActivity" />
         <activity android:name=".ui.favoritelists.FavoriteListSongsActivity" />
         <activity android:name=".ui.favoritelists.FavoriteListImportActivity" />

--- a/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
@@ -1,0 +1,18 @@
+package de.jeisfeld.songarchive
+
+import android.app.Application
+import de.jeisfeld.songarchive.db.AppDatabase
+import de.jeisfeld.songarchive.db.AppMetadata
+import de.jeisfeld.songarchive.utils.LanguageUtil
+import kotlinx.coroutines.runBlocking
+
+class SongArchiveApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        val dao = AppDatabase.getDatabase(this).appMetadataDao()
+        runBlocking {
+            val metadata = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
+            LanguageUtil.applyAppLanguage(metadata.language)
+        }
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -4,10 +4,12 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
-    version = 12,
+    version = 13,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -19,6 +21,14 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        private val MIGRATION_12_13 = object : Migration(12, 13) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE app_metadata ADD COLUMN language TEXT NOT NULL DEFAULT 'system'"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -26,7 +36,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "songs.db"
                 )
-                    .fallbackToDestructiveMigration()
+                    .addMigrations(MIGRATION_12_13)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
@@ -7,5 +7,6 @@ import androidx.room.PrimaryKey
 data class AppMetadata(
     @PrimaryKey val id: Int = 1,  // Always only one row
     val numberOfTabs: Int,
-    val chordsZipSize: Long
+    val chordsZipSize: Long,
+    val language: String = "system"
 )

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -217,7 +217,8 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
                 Log.d(TAG, "Remote Metadata: " + checkUpdateResponse)
 
                 val localMetadata =
-                    AppDatabase.getDatabase(getApplication()).appMetadataDao().get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0)
+                    AppDatabase.getDatabase(getApplication()).appMetadataDao().get()
+                        ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
                 Log.d(TAG, "Local Metadata: " + localMetadata)
 
                 val tabsChanged = checkUpdateResponse?.tab_count != null && checkUpdateResponse?.tab_count != localMetadata.numberOfTabs
@@ -235,8 +236,10 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
         CoroutineScope(Dispatchers.IO).launch {
             checkUpdateResponse?.tab_count?.let { tabCount ->
                 checkUpdateResponse?.chords_zip_size?.let { zipSize ->
-                    AppDatabase.getDatabase(getApplication()).appMetadataDao().insert(
-                        AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize)
+                    val dao = AppDatabase.getDatabase(getApplication()).appMetadataDao()
+                    val existing = dao.get() ?: AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize, language = "system")
+                    dao.insert(
+                        existing.copy(numberOfTabs = tabCount, chordsZipSize = zipSize)
                     )
                 }
             }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/ChordsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/ChordsViewerActivity.kt
@@ -8,7 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
@@ -62,7 +62,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 
-class ChordsViewerActivity : ComponentActivity() {
+class ChordsViewerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
@@ -4,7 +4,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
@@ -51,7 +51,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class LyricsViewerActivity : ComponentActivity() {
+class LyricsViewerActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
@@ -4,7 +4,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.Build
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -66,7 +66,7 @@ import de.jeisfeld.songarchive.network.PeerConnectionViewModel
 import de.jeisfeld.songarchive.ui.theme.AppColors
 import de.jeisfeld.songarchive.ui.theme.AppTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     lateinit var viewModel: SongViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListImportActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListImportActivity.kt
@@ -1,7 +1,7 @@
 package de.jeisfeld.songarchive.ui.favoritelists
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.ViewModelProvider
 import de.jeisfeld.songarchive.db.FavoriteListViewModel
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 import androidx.compose.ui.res.stringResource
 import de.jeisfeld.songarchive.R
 
-class FavoriteListImportActivity: ComponentActivity() {
+class FavoriteListImportActivity: AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val listName = intent.getStringExtra("LIST_NAME") ?: ""

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListSongsActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListSongsActivity.kt
@@ -1,7 +1,7 @@
 package de.jeisfeld.songarchive.ui.favoritelists
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -12,7 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class FavoriteListSongsActivity : ComponentActivity() {
+class FavoriteListSongsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val songViewModel = ViewModelProvider(this)[SongViewModel::class.java]

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsActivity.kt
@@ -1,13 +1,13 @@
 package de.jeisfeld.songarchive.ui.favoritelists
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.ViewModelProvider
 import de.jeisfeld.songarchive.db.FavoriteListViewModel
 import de.jeisfeld.songarchive.ui.theme.AppTheme
 
-class FavoriteListsActivity : ComponentActivity() {
+class FavoriteListsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val viewModel = ViewModelProvider(this)[FavoriteListViewModel::class.java]

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsActivity.kt
@@ -1,13 +1,15 @@
 package de.jeisfeld.songarchive.ui.settings
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.ViewModelProvider
 import de.jeisfeld.songarchive.ui.theme.AppTheme
 
-class SettingsActivity : ComponentActivity() {
+class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent { AppTheme { SettingsScreen { finish() } } }
+        val viewModel = ViewModelProvider(this)[SettingsViewModel::class.java]
+        setContent { AppTheme { SettingsScreen(viewModel) { finish() } } }
     }
 }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
@@ -5,30 +5,44 @@ import android.provider.Settings
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.Alignment
 import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.ui.theme.AppColors
+import de.jeisfeld.songarchive.utils.LanguageUtil
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(onClose: () -> Unit) {
+fun SettingsScreen(viewModel: SettingsViewModel, onClose: () -> Unit) {
     val context = LocalContext.current
+    val selectedLanguage by viewModel.language.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -61,6 +75,62 @@ fun SettingsScreen(onClose: () -> Unit) {
                 style = MaterialTheme.typography.headlineSmall
             )
             Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
+
+            val options = listOf("system", "en", "de")
+            val optionTexts = stringArrayResource(id = R.array.app_language_options)
+            var showDialog by remember { mutableStateOf(false) }
+            val selectedText = optionTexts[options.indexOf(selectedLanguage)]
+
+            TextButton(onClick = { showDialog = true }) {
+                Text(stringResource(id = R.string.app_language) + ": " + selectedText)
+            }
+
+            if (showDialog) {
+                AlertDialog(
+                    onDismissRequest = { showDialog = false },
+                    title = { Text(stringResource(id = R.string.app_language)) },
+                    text = {
+                        Column {
+                            options.forEachIndexed { index, option ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            viewModel.setLanguage(option)
+                                            LanguageUtil.applyAppLanguage(option)
+                                            showDialog = false
+                                        }
+                                ) {
+                                    RadioButton(
+                                        selected = selectedLanguage == option,
+                                        onClick = {
+                                            viewModel.setLanguage(option)
+                                            LanguageUtil.applyAppLanguage(option)
+                                            showDialog = false
+                                        },
+                                        colors = RadioButtonDefaults.colors(
+                                            selectedColor = AppColors.TextColor,
+                                            unselectedColor = AppColors.TextColorLight
+                                        )
+                                    )
+                                    Text(
+                                        text = optionTexts[index],
+                                        modifier = Modifier.padding(start = dimensionResource(id = R.dimen.spacing_medium)),
+                                        color = AppColors.TextColor
+                                    )
+                                }
+                            }
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { showDialog = false }) { Text(stringResource(id = R.string.cancel)) }
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
+
             TextButton(onClick = {
                 val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)
                 context.startActivity(intent)

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsViewModel.kt
@@ -1,0 +1,31 @@
+package de.jeisfeld.songarchive.ui.settings
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import de.jeisfeld.songarchive.db.AppDatabase
+import de.jeisfeld.songarchive.db.AppMetadata
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class SettingsViewModel(application: Application) : AndroidViewModel(application) {
+    private val dao = AppDatabase.getDatabase(application).appMetadataDao()
+
+    private val _language = MutableStateFlow("system")
+    val language: StateFlow<String> = _language
+
+    init {
+        viewModelScope.launch {
+            _language.value = dao.get()?.language ?: "system"
+        }
+    }
+
+    fun setLanguage(lang: String) {
+        _language.value = lang
+        viewModelScope.launch {
+            val current = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = lang)
+            dao.insert(current.copy(language = lang))
+        }
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/utils/LanguageUtil.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/utils/LanguageUtil.kt
@@ -1,0 +1,19 @@
+package de.jeisfeld.songarchive.utils
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import java.util.Locale
+
+object LanguageUtil {
+    fun applyAppLanguage(language: String) {
+        val locales = when (language) {
+            "en" -> LocaleListCompat.forLanguageTags("en")
+            "de" -> LocaleListCompat.forLanguageTags("de")
+            else -> LocaleListCompat.getEmptyLocaleList()
+        }
+        if (!locales.isEmpty) {
+            Locale.setDefault(locales[0]!!)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,4 +74,10 @@
         <item>Texte (weiß/schwarz)</item>
         <item>Akkorde</item>
     </string-array>
+    <string name="app_language">App-Sprache</string>
+    <string-array name="app_language_options">
+        <item>System</item>
+        <item>Englisch</item>
+        <item>Deutsch</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,4 +74,10 @@
         <item>Lyrics (white/black)</item>
         <item>Chords</item>
     </string-array>
+    <string name="app_language">App Language</string>
+    <string-array name="app_language_options">
+        <item>System</item>
+        <item>English</item>
+        <item>German</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.CircleSongArchive" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.CircleSongArchive" parent="Theme.Material3.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
## Summary
- add a `language` column to `AppMetadata`
- migrate Room database from version 12 to 13
- introduce `SongArchiveApp` and `LanguageUtil` to apply the selected locale
- create `SettingsViewModel` and update Settings screen to choose app language
- add app language strings (EN/DE) and remove destructive migrations
- include appcompat library
- **fix language setting UI to open a dialog and apply locale correctly**
- use `AppCompatActivity` so locale changes apply
- switch to an AppCompat-compatible theme so activities launch correctly

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888c813f39c832291a436bc6692fe05