### PR TITLE
Add default network connection type setting

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
@@ -11,7 +11,7 @@ class SongArchiveApp : Application() {
         super.onCreate()
         val dao = AppDatabase.getDatabase(this).appMetadataDao()
         runBlocking {
-            val metadata = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
+            val metadata = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system", defaultConnectionType = 0)
             LanguageUtil.applyAppLanguage(metadata.language)
         }
     }

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -42,6 +42,14 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE app_metadata ADD COLUMN defaultConnectionType INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -49,7 +57,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "songs.db"
                 )
-                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13)
+                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
@@ -8,5 +8,6 @@ data class AppMetadata(
     @PrimaryKey val id: Int = 1,  // Always only one row
     val numberOfTabs: Int,
     val chordsZipSize: Long,
-    val language: String = "system"
+    val language: String = "system",
+    val defaultConnectionType: Int = 0
 )

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -218,7 +218,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
 
                 val localMetadata =
                     AppDatabase.getDatabase(getApplication()).appMetadataDao().get()
-                        ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
+                        ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system", defaultConnectionType = 0)
                 Log.d(TAG, "Local Metadata: " + localMetadata)
 
                 val tabsChanged = checkUpdateResponse?.tab_count != null && checkUpdateResponse?.tab_count != localMetadata.numberOfTabs
@@ -237,7 +237,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
             checkUpdateResponse?.tab_count?.let { tabCount ->
                 checkUpdateResponse?.chords_zip_size?.let { zipSize ->
                     val dao = AppDatabase.getDatabase(getApplication()).appMetadataDao()
-                    val existing = dao.get() ?: AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize, language = "system")
+                    val existing = dao.get() ?: AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize, language = "system", defaultConnectionType = 0)
                     dao.insert(
                         existing.copy(numberOfTabs = tabCount, chordsZipSize = zipSize)
                     )

--- a/app/src/main/java/de/jeisfeld/songarchive/network/DefaultConnectionType.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/network/DefaultConnectionType.kt
@@ -1,0 +1,24 @@
+package de.jeisfeld.songarchive.network
+
+enum class DefaultConnectionType(val value: Int) {
+    NONE(0),
+    SERVER(1),
+    CLIENT_LYRICS_BS(2),
+    CLIENT_LYRICS_BW(3),
+    CLIENT_LYRICS_WB(4),
+    CLIENT_CHORDS(5);
+
+    companion object {
+        fun fromInt(value: Int): DefaultConnectionType = values().firstOrNull { it.value == value } ?: NONE
+    }
+
+    fun toModes(): Pair<PeerConnectionMode, ClientMode> = when(this) {
+        SERVER -> PeerConnectionMode.SERVER to PeerConnectionViewModel.clientMode
+        CLIENT_LYRICS_BS -> PeerConnectionMode.CLIENT to ClientMode.LYRICS_BS
+        CLIENT_LYRICS_BW -> PeerConnectionMode.CLIENT to ClientMode.LYRICS_BW
+        CLIENT_LYRICS_WB -> PeerConnectionMode.CLIENT to ClientMode.LYRICS_WB
+        CLIENT_CHORDS -> PeerConnectionMode.CLIENT to ClientMode.CHORDS
+        NONE -> PeerConnectionMode.DISABLED to PeerConnectionViewModel.clientMode
+    }
+}
+

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
@@ -4,24 +4,32 @@ import android.Manifest
 import android.content.Context
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import de.jeisfeld.songarchive.R
+import de.jeisfeld.songarchive.db.AppDatabase
+import de.jeisfeld.songarchive.network.DefaultConnectionType
 import de.jeisfeld.songarchive.network.PeerConnectionMode
 import de.jeisfeld.songarchive.network.PeerConnectionViewModel
+import de.jeisfeld.songarchive.network.PeerConnectionService
+import de.jeisfeld.songarchive.network.PeerConnectionAction
+import de.jeisfeld.songarchive.network.ClientMode
 import de.jeisfeld.songarchive.network.isNearbyConnectionPossible
 import de.jeisfeld.songarchive.ui.NetworkModeMenu
 import de.jeisfeld.songarchive.ui.theme.AppColors
@@ -38,6 +46,11 @@ fun MainDropdownMenu(
     onSync: () -> Unit,
 ) {
     var showNetworkMenu by remember { mutableStateOf(false) }
+    var defaultConnectionType by remember { mutableStateOf(DefaultConnectionType.NONE) }
+    LaunchedEffect(Unit) {
+        val dao = AppDatabase.getDatabase(context).appMetadataDao()
+        defaultConnectionType = DefaultConnectionType.fromInt(dao.get()?.defaultConnectionType ?: 0)
+    }
 
     DropdownMenu(
         expanded = showMenu,
@@ -109,14 +122,71 @@ fun MainDropdownMenu(
                         color = AppColors.TextColor
                     )
                 },
-                onClick = {
-                    showNetworkMenu = true
-                },
+                onClick = {},
                 leadingIcon = {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_wifi),
                         contentDescription = "Wi-Fi Transfer",
                         modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                    )
+                },
+                modifier = Modifier.pointerInput(defaultConnectionType) {
+                    detectTapGestures(
+                        onTap = {
+                            if (defaultConnectionType == DefaultConnectionType.NONE) {
+                                showNetworkMenu = true
+                            } else {
+                                val target = if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.DISABLED) {
+                                    defaultConnectionType.toModes()
+                                } else {
+                                    PeerConnectionMode.DISABLED to PeerConnectionViewModel.clientMode
+                                }
+                                val isPeerConnectionModeChanged = target.first != PeerConnectionViewModel.peerConnectionMode
+                                PeerConnectionViewModel.peerConnectionMode = target.first
+                                PeerConnectionViewModel.clientMode = target.second
+                                onDismissRequest()
+                                showNetworkMenu = false
+                                val requiredPermissions = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                                    arrayOf(
+                                        Manifest.permission.NEARBY_WIFI_DEVICES,
+                                        Manifest.permission.ACCESS_FINE_LOCATION,
+                                        Manifest.permission.BLUETOOTH,
+                                        Manifest.permission.BLUETOOTH_SCAN,
+                                        Manifest.permission.BLUETOOTH_ADMIN,
+                                        Manifest.permission.BLUETOOTH_CONNECT,
+                                        Manifest.permission.BLUETOOTH_ADVERTISE
+                                    )
+                                } else if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                                    arrayOf(
+                                        Manifest.permission.ACCESS_FINE_LOCATION,
+                                        Manifest.permission.BLUETOOTH,
+                                        Manifest.permission.BLUETOOTH_SCAN,
+                                        Manifest.permission.BLUETOOTH_ADMIN,
+                                        Manifest.permission.BLUETOOTH_CONNECT,
+                                        Manifest.permission.BLUETOOTH_ADVERTISE
+                                    )
+                                } else {
+                                    arrayOf(
+                                        Manifest.permission.ACCESS_FINE_LOCATION,
+                                        Manifest.permission.BLUETOOTH,
+                                        Manifest.permission.BLUETOOTH_ADMIN,
+                                    )
+                                }
+                                val missingPermissions = requiredPermissions.filter {
+                                    ContextCompat.checkSelfPermission(context, it) != android.content.pm.PackageManager.PERMISSION_GRANTED
+                                }
+                                if (isPeerConnectionModeChanged) {
+                                    if (missingPermissions.isNotEmpty()) {
+                                        permissionLauncher.launch(missingPermissions.toTypedArray())
+                                    } else {
+                                        PeerConnectionViewModel.startPeerConnectionService(context)
+                                    }
+                                }
+                            }
+                        },
+                        onLongPress = {
+                            showNetworkMenu = true
+                        }
                     )
                 }
             )

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ import de.jeisfeld.songarchive.utils.LanguageUtil
 fun SettingsScreen(viewModel: SettingsViewModel, onClose: () -> Unit) {
     val context = LocalContext.current
     val selectedLanguage by viewModel.language.collectAsState()
+    val selectedConnectionType by viewModel.defaultConnectionType.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -131,6 +132,57 @@ fun SettingsScreen(viewModel: SettingsViewModel, onClose: () -> Unit) {
             }
 
             Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
+
+            val connectionOptions = (0..5).toList()
+            val connectionTexts = stringArrayResource(id = R.array.default_network_connection_type_options)
+            var showConnectionDialog by remember { mutableStateOf(false) }
+            val selectedConnectionText = connectionTexts[selectedConnectionType]
+
+            TextButton(onClick = { showConnectionDialog = true }) {
+                Text(stringResource(id = R.string.default_network_connection_type) + ": " + selectedConnectionText)
+            }
+
+            if (showConnectionDialog) {
+                AlertDialog(
+                    onDismissRequest = { showConnectionDialog = false },
+                    title = { Text(stringResource(id = R.string.default_network_connection_type)) },
+                    text = {
+                        Column {
+                            connectionOptions.forEach { option ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            viewModel.setDefaultConnectionType(option)
+                                            showConnectionDialog = false
+                                        }
+                                ) {
+                                    RadioButton(
+                                        selected = selectedConnectionType == option,
+                                        onClick = {
+                                            viewModel.setDefaultConnectionType(option)
+                                            showConnectionDialog = false
+                                        },
+                                        colors = RadioButtonDefaults.colors(
+                                            selectedColor = AppColors.TextColor,
+                                            unselectedColor = AppColors.TextColorLight
+                                        )
+                                    )
+                                    Text(
+                                        text = connectionTexts[option],
+                                        modifier = Modifier.padding(start = dimensionResource(id = R.dimen.spacing_medium)),
+                                        color = AppColors.TextColor
+                                    )
+                                }
+                            }
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { showConnectionDialog = false }) { Text(stringResource(id = R.string.cancel)) }
+                    }
+                )
+            }
 
             TextButton(onClick = {
                 val intent = Intent(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS)

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsViewModel.kt
@@ -14,18 +14,30 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     private val _language = MutableStateFlow("system")
     val language: StateFlow<String> = _language
+    private val _defaultConnectionType = MutableStateFlow(0)
+    val defaultConnectionType: StateFlow<Int> = _defaultConnectionType
 
     init {
         viewModelScope.launch {
-            _language.value = dao.get()?.language ?: "system"
+            val metadata = dao.get()
+            _language.value = metadata?.language ?: "system"
+            _defaultConnectionType.value = metadata?.defaultConnectionType ?: 0
         }
     }
 
     fun setLanguage(lang: String) {
         _language.value = lang
         viewModelScope.launch {
-            val current = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = lang)
+            val current = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = lang, defaultConnectionType = _defaultConnectionType.value)
             dao.insert(current.copy(language = lang))
+        }
+    }
+
+    fun setDefaultConnectionType(type: Int) {
+        _defaultConnectionType.value = type
+        viewModelScope.launch {
+            val current = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = _language.value, defaultConnectionType = type)
+            dao.insert(current.copy(defaultConnectionType = type))
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,6 +74,15 @@
         <item>Texte (weiß/schwarz)</item>
         <item>Akkorde</item>
     </string-array>
+    <string name="default_network_connection_type">Standard-Netzwerkverbindung</string>
+    <string-array name="default_network_connection_type_options">
+        <item>Keine</item>
+        <item>Sender</item>
+        <item>Empfänger Texte (schwarz/sepia)</item>
+        <item>Empfänger Texte (schwarz/weiß)</item>
+        <item>Empfänger Texte (weiß/schwarz)</item>
+        <item>Empfänger Akkorde</item>
+    </string-array>
     <string name="app_language">App-Sprache</string>
     <string-array name="app_language_options">
         <item>System</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,15 @@
         <item>Lyrics (white/black)</item>
         <item>Chords</item>
     </string-array>
+    <string name="default_network_connection_type">Default Network Connection Type</string>
+    <string-array name="default_network_connection_type_options">
+        <item>None</item>
+        <item>Server</item>
+        <item>Client Lyrics (black/sepia)</item>
+        <item>Client Lyrics (black/white)</item>
+        <item>Client Lyrics (white/black)</item>
+        <item>Client Chords</item>
+    </string-array>
     <string name="app_language">App Language</string>
     <string-array name="app_language_options">
         <item>System</item>


### PR DESCRIPTION
## Summary
- introduce `defaultConnectionType` column for `AppMetadata`
- migrate database to version 14
- add enum `DefaultConnectionType`
- allow setting default connection type in settings screen
- toggle network mode directly from dropdown if a default is configured
- update translations for new texts

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6888e07fb72c832290b8c1a9d9ed81b9