### PR TITLE
Add default network connection setting

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     // Jetpack Compose UI
     implementation(libs.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Room für SQLite-Datenbank
     implementation(libs.androidx.room.runtime)

--- a/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/SongArchiveApp.kt
@@ -11,7 +11,7 @@ class SongArchiveApp : Application() {
         super.onCreate()
         val dao = AppDatabase.getDatabase(this).appMetadataDao()
         runBlocking {
-            val metadata = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
+            val metadata = dao.get() ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system", defaultNetworkConnection = 0)
             LanguageUtil.applyAppLanguage(metadata.language)
         }
     }

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -42,6 +42,14 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    "ALTER TABLE app_metadata ADD COLUMN defaultNetworkConnection INTEGER NOT NULL DEFAULT 0"
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -49,7 +57,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "songs.db"
                 )
-                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13)
+                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppMetadata.kt
@@ -8,5 +8,6 @@ data class AppMetadata(
     @PrimaryKey val id: Int = 1,  // Always only one row
     val numberOfTabs: Int,
     val chordsZipSize: Long,
-    val language: String = "system"
+    val language: String = "system",
+    val defaultNetworkConnection: Int = 0
 )

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -218,7 +218,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
 
                 val localMetadata =
                     AppDatabase.getDatabase(getApplication()).appMetadataDao().get()
-                        ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system")
+                        ?: AppMetadata(numberOfTabs = 0, chordsZipSize = 0, language = "system", defaultNetworkConnection = 0)
                 Log.d(TAG, "Local Metadata: " + localMetadata)
 
                 val tabsChanged = checkUpdateResponse?.tab_count != null && checkUpdateResponse?.tab_count != localMetadata.numberOfTabs
@@ -237,7 +237,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
             checkUpdateResponse?.tab_count?.let { tabCount ->
                 checkUpdateResponse?.chords_zip_size?.let { zipSize ->
                     val dao = AppDatabase.getDatabase(getApplication()).appMetadataDao()
-                    val existing = dao.get() ?: AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize, language = "system")
+                    val existing = dao.get() ?: AppMetadata(numberOfTabs = tabCount, chordsZipSize = zipSize, language = "system", defaultNetworkConnection = 0)
                     dao.insert(
                         existing.copy(numberOfTabs = tabCount, chordsZipSize = zipSize)
                     )

--- a/app/src/main/java/de/jeisfeld/songarchive/network/DefaultNetworkConnection.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/network/DefaultNetworkConnection.kt
@@ -1,0 +1,16 @@
+package de.jeisfeld.songarchive.network
+
+enum class DefaultNetworkConnection(val id: Int) {
+    NONE(0),
+    SERVER(1),
+    CLIENT_LYRICS_BS(2),
+    CLIENT_LYRICS_BW(3),
+    CLIENT_LYRICS_WB(4),
+    CLIENT_CHORDS(5);
+
+    companion object {
+        fun fromId(id: Int): DefaultNetworkConnection {
+            return values().find { it.id == id } ?: NONE
+        }
+    }
+}

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/settings/SettingsScreen.kt
@@ -44,6 +44,7 @@ import de.jeisfeld.songarchive.utils.LanguageUtil
 fun SettingsScreen(viewModel: SettingsViewModel, onClose: () -> Unit) {
     val context = LocalContext.current
     val selectedLanguage by viewModel.language.collectAsState()
+    val selectedDefaultConnection by viewModel.defaultNetworkConnection.collectAsState()
     Scaffold(
         topBar = {
             TopAppBar(
@@ -126,6 +127,59 @@ fun SettingsScreen(viewModel: SettingsViewModel, onClose: () -> Unit) {
                     },
                     confirmButton = {
                         TextButton(onClick = { showDialog = false }) { Text(stringResource(id = R.string.cancel)) }
+                    }
+                )
+            }
+
+            Spacer(modifier = Modifier.padding(dimensionResource(id = R.dimen.spacing_small)))
+
+            val connectionOptions = listOf(0, 1, 2, 3, 4, 5)
+            val connectionTexts = stringArrayResource(id = R.array.default_connection_options)
+            var showConnectionDialog by remember { mutableStateOf(false) }
+            val selectedConnectionText = connectionTexts[selectedDefaultConnection]
+
+            TextButton(onClick = { showConnectionDialog = true }) {
+                Text(stringResource(id = R.string.default_network_connection) + ": " + selectedConnectionText)
+            }
+
+            if (showConnectionDialog) {
+                AlertDialog(
+                    onDismissRequest = { showConnectionDialog = false },
+                    title = { Text(stringResource(id = R.string.default_network_connection)) },
+                    text = {
+                        Column {
+                            connectionOptions.forEach { option ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable {
+                                            viewModel.setDefaultNetworkConnection(option)
+                                            showConnectionDialog = false
+                                        }
+                                ) {
+                                    RadioButton(
+                                        selected = selectedDefaultConnection == option,
+                                        onClick = {
+                                            viewModel.setDefaultNetworkConnection(option)
+                                            showConnectionDialog = false
+                                        },
+                                        colors = RadioButtonDefaults.colors(
+                                            selectedColor = AppColors.TextColor,
+                                            unselectedColor = AppColors.TextColorLight
+                                        )
+                                    )
+                                    Text(
+                                        text = connectionTexts[option],
+                                        modifier = Modifier.padding(start = dimensionResource(id = R.dimen.spacing_medium)),
+                                        color = AppColors.TextColor
+                                    )
+                                }
+                            }
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = { showConnectionDialog = false }) { Text(stringResource(id = R.string.cancel)) }
                     }
                 )
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -80,4 +80,13 @@
         <item>Englisch</item>
         <item>Deutsch</item>
     </string-array>
+    <string name="default_network_connection">Standard-Netzwerkverbindung</string>
+    <string-array name="default_connection_options">
+        <item>Keine</item>
+        <item>Sender</item>
+        <item>Texte (schwarz/sepia)</item>
+        <item>Texte (schwarz/weiß)</item>
+        <item>Texte (weiß/schwarz)</item>
+        <item>Akkorde</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,4 +80,13 @@
         <item>English</item>
         <item>German</item>
     </string-array>
+    <string name="default_network_connection">Default Network Connection</string>
+    <string-array name="default_connection_options">
+        <item>None</item>
+        <item>Server</item>
+        <item>Lyrics (black/sepia)</item>
+        <item>Lyrics (black/white)</item>
+        <item>Lyrics (white/black)</item>
+        <item>Chords</item>
+    </string-array>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-nearby = { module = "com.google.android.gms:play-services-nearby", version.ref = "playServicesNearby" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
+androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }


### PR DESCRIPTION
## Summary
- add DefaultNetworkConnection enum
- store default network connection in AppMetadata
- handle new DB migration and version
- expose default connection via SettingsViewModel and SettingsScreen
- toggle connection quickly in MainDropdownMenu
- add English/German strings for the setting
- **add missing lifecycle dependency**

## Testing
- `./gradlew lint --no-daemon` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6888e07fb72c832290b8c1a9d9ed81b9