### PR TITLE
Fix MainDropdownMenu network item long press

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainDropdownMenu.kt
@@ -5,12 +5,9 @@ import android.content.Context
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -21,7 +18,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
@@ -114,8 +110,7 @@ fun MainDropdownMenu(
             }
         )
         if (isNearbyConnectionPossible(context)) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .combinedClickable(
@@ -155,18 +150,22 @@ fun MainDropdownMenu(
                         },
                         onLongClick = { showNetworkMenu = true }
                     )
-                    .padding(vertical = dimensionResource(id = R.dimen.spacing_vertical_medium),
-                        horizontal = dimensionResource(id = R.dimen.spacing_medium))
             ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_wifi),
-                    contentDescription = "Wi-Fi Transfer",
-                    modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
-                )
-                Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
-                Text(
-                    stringResource(id = R.string.network_connection),
-                    color = AppColors.TextColor
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            stringResource(id = R.string.network_connection),
+                            color = AppColors.TextColor
+                        )
+                    },
+                    onClick = {},
+                    leadingIcon = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_wifi),
+                            contentDescription = "Wi-Fi Transfer",
+                            modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                        )
+                    }
                 )
             }
         }


### PR DESCRIPTION
## Summary
- wrap network connection entry in a `Box` and handle clicks via `combinedClickable`
- remove unused gesture imports

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68891a5100f883229e8f64c847cf931f