### PR TITLE
Fix chunk button overflow in viewer

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/ViewerControlButtons.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/ViewerControlButtons.kt
@@ -7,6 +7,8 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -93,7 +95,17 @@ fun ViewerControlButtons(
             enter = fadeIn(),
             exit = fadeOut()
         ) {
-            Row {
+            // Calculate the lyrics chunks once so we can decide how to layout
+            // the chunk buttons.
+            val chunks = if (displayStyle == DisplayStyle.STANDARD && (hasSentLyrics || isShowingLyrics)) {
+                song?.lyricsPaged?.let { listOf(null as String?) + it.split('|').map { part -> part.trim() } }
+            } else {
+                null
+            }
+            val showChunksInSeparateRow = chunks?.size ?: 0 > 4
+
+            Column(horizontalAlignment = Alignment.End) {
+                Row {
                 if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER && PeerConnectionViewModel.connectedDevices > 0
                     && displayStyle == DisplayStyle.STANDARD
                 ) {
@@ -156,64 +168,61 @@ fun ViewerControlButtons(
                     Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                 }
 
-                if (displayStyle == DisplayStyle.STANDARD && (hasSentLyrics || isShowingLyrics)) {
-                    val lyricsPaged = song?.lyricsPaged
-                    if (lyricsPaged != null) {
-                        val chunks = listOf(null as String?) + lyricsPaged.split('|').map { it.trim() }
+                if (!showChunksInSeparateRow) {
+                    chunks?.forEachIndexed { index, chunk ->
+                        val circledNumber = when (index) {
+                            0 -> "\u24EA" // ⓪ full lyrics
+                            in 1..20 -> (0x2460 + index - 1).toChar().toString() // ① to ⑳
+                            else -> index.toString() // fallback
+                        }
 
-                        chunks.forEachIndexed { index, chunk ->
-                            val circledNumber = when (index) {
-                                0 -> "\u24EA" // ⓪ full lyrics
-                                in 1..20 -> (0x2460 + index - 1).toChar().toString() // ① to ⑳
-                                else -> index.toString() // fallback
-                            }
+                        IconButton(
+                            onClick = {
+                                currentChunk = chunk
+                                onDisplayLyricsPage(chunk)
 
-                            IconButton(
-                                onClick = {
-                                    currentChunk = chunk
-                                    onDisplayLyricsPage(chunk)
-
-                                    if (hasSentLyrics) {
-                                        val serviceIntent = Intent(context, PeerConnectionService::class.java).apply {
-                                            setAction(PeerConnectionAction.DISPLAY_LYRICS.toString())
-                                            putExtra("ACTION", PeerConnectionAction.DISPLAY_LYRICS)
-                                            putExtra("STYLE", DisplayStyle.REMOTE_DEFAULT)
-                                            if (index == 0) {
-                                                putExtra("SONG_ID", song.id)
-                                                putExtra("LYRICS", song.lyrics)
-                                                putExtra("LYRICS_SHORT", song.lyricsShort)                                            }
-                                            else {
-                                                putExtra("LYRICS", chunk)
-                                            }
+                                if (hasSentLyrics) {
+                                    val serviceIntent = Intent(context, PeerConnectionService::class.java).apply {
+                                        setAction(PeerConnectionAction.DISPLAY_LYRICS.toString())
+                                        putExtra("ACTION", PeerConnectionAction.DISPLAY_LYRICS)
+                                        putExtra("STYLE", DisplayStyle.REMOTE_DEFAULT)
+                                        if (index == 0) {
+                                            putExtra("SONG_ID", song?.id)
+                                            putExtra("LYRICS", song?.lyrics)
+                                            putExtra("LYRICS_SHORT", song?.lyricsShort)
+                                        } else {
+                                            putExtra("LYRICS", chunk)
                                         }
-                                        context.startService(serviceIntent)
                                     }
-                                },
-                                modifier = Modifier
-                                    .background(
-                                        Brush.verticalGradient(
-                                            listOf(Color.White.copy(alpha = 0.6f), Color.White.copy(alpha = 0.3f))
-                                        ),
-                                        shape = RoundedCornerShape(50)
-                                    )
-                                    .size(dimensionResource(id = R.dimen.icon_size_large))
-                                    .clip(RoundedCornerShape(50))
-                            ) {
-                                Box(
-                                    contentAlignment = Alignment.Center,
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .background(Color.Transparent)
-                                ) {
-                                    Text(
-                                        text = circledNumber,
-                                        color = Color.Black,
-                                        fontSize = dimensionResource(id = R.dimen.icon_font_large).value.sp,
-                                        fontWeight = FontWeight.Bold
-                                    )
+                                    context.startService(serviceIntent)
                                 }
+                            },
+                            modifier = Modifier
+                                .background(
+                                    Brush.verticalGradient(
+                                        listOf(Color.White.copy(alpha = 0.6f), Color.White.copy(alpha = 0.3f))
+                                    ),
+                                    shape = RoundedCornerShape(50)
+                                )
+                                .size(dimensionResource(id = R.dimen.icon_size_large))
+                                .clip(RoundedCornerShape(50))
+                        ) {
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(Color.Transparent)
+                            ) {
+                                Text(
+                                    text = circledNumber,
+                                    color = Color.Black,
+                                    fontSize = dimensionResource(id = R.dimen.icon_font_large).value.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
                             }
                         }
+                    }
+                    if (chunks != null) {
                         Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                     }
                 }
@@ -351,6 +360,71 @@ fun ViewerControlButtons(
                         tint = Color.Black,
                         modifier = Modifier.padding(8.dp).size(dimensionResource(id = R.dimen.icon_size_small))
                     )
+                }
+
+                if (showChunksInSeparateRow) {
+                    Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
+                }
+            }
+            if (showChunksInSeparateRow) {
+                Spacer(modifier = Modifier.height(dimensionResource(id = R.dimen.spacing_medium)))
+                FlowRow(
+                    mainAxisSpacing = dimensionResource(id = R.dimen.spacing_small),
+                    crossAxisSpacing = dimensionResource(id = R.dimen.spacing_small),
+                ) {
+                    chunks?.forEachIndexed { index, chunk ->
+                        val circledNumber = when (index) {
+                            0 -> "\u24EA" // ⓪ full lyrics
+                            in 1..20 -> (0x2460 + index - 1).toChar().toString() // ① to ⑳
+                            else -> index.toString()
+                        }
+
+                        IconButton(
+                            onClick = {
+                                currentChunk = chunk
+                                onDisplayLyricsPage(chunk)
+
+                                if (hasSentLyrics) {
+                                    val serviceIntent = Intent(context, PeerConnectionService::class.java).apply {
+                                        setAction(PeerConnectionAction.DISPLAY_LYRICS.toString())
+                                        putExtra("ACTION", PeerConnectionAction.DISPLAY_LYRICS)
+                                        putExtra("STYLE", DisplayStyle.REMOTE_DEFAULT)
+                                        if (index == 0) {
+                                            putExtra("SONG_ID", song?.id)
+                                            putExtra("LYRICS", song?.lyrics)
+                                            putExtra("LYRICS_SHORT", song?.lyricsShort)
+                                        } else {
+                                            putExtra("LYRICS", chunk)
+                                        }
+                                    }
+                                    context.startService(serviceIntent)
+                                }
+                            },
+                            modifier = Modifier
+                                .background(
+                                    Brush.verticalGradient(
+                                        listOf(Color.White.copy(alpha = 0.6f), Color.White.copy(alpha = 0.3f))
+                                    ),
+                                    shape = RoundedCornerShape(50)
+                                )
+                                .size(dimensionResource(id = R.dimen.icon_size_large))
+                                .clip(RoundedCornerShape(50))
+                        ) {
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(Color.Transparent)
+                            ) {
+                                Text(
+                                    text = circledNumber,
+                                    color = Color.Black,
+                                    fontSize = dimensionResource(id = R.dimen.icon_font_large).value.sp,
+                                    fontWeight = FontWeight.Bold
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- prevent overflow of chunk buttons in `ViewerControlButtons`
- move chunk buttons to a second row when there are more than 4 chunks

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*


------
https://chatgpt.com/codex/tasks/task_e_688a12d4c4088322a91dee8752472504