### PR TITLE
Add shuffle option when search field empty

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
 
     // Jetpack Compose UI
     implementation(libs.ui)
+    implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Room für SQLite-Datenbank

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongDao.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongDao.kt
@@ -123,6 +123,9 @@ interface SongDao {
         word5a: String
     ): Flow<List<Song>>
 
+    @Query("SELECT * FROM songs ORDER BY RANDOM()")
+    fun getSongsShuffled(): Flow<List<Song>>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSongs(songs: List<Song>)
 

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -75,6 +75,14 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun shuffleSongs() {
+        viewModelScope.launch {
+            songDao.getSongsShuffled().collectLatest { results ->
+                _songs.value = results
+            }
+        }
+    }
+
     fun synchronizeDatabaseAndImages(recheckUpdate: Boolean, onComplete: (Boolean) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             try {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
@@ -34,6 +34,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Shuffle
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -372,6 +374,15 @@ fun SearchBar(viewModel: SongViewModel) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_close),
                         contentDescription = "Clear",
+                        tint = Color.Gray,
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                    )
+                }
+            } else {
+                IconButton(onClick = { viewModel.shuffleSongs() }) {
+                    Icon(
+                        imageVector = Icons.Default.Shuffle,
+                        contentDescription = "Shuffle",
                         tint = Color.Gray,
                         modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
                     )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@ androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "u
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "materialVersion" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "ui" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- show shuffle icon when search bar is empty
- randomize songs list via new DAO query and ViewModel function
- include material icons dependency for shuffle icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc69d150c8322b1c53c2054788976