### PR TITLE
Add shuffle option to search

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongDao.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongDao.kt
@@ -141,6 +141,9 @@ interface SongDao {
     @Query("SELECT * FROM songs")
     suspend fun getAllSongs(): List<Song>
 
+    @Query("SELECT * FROM songs ORDER BY RANDOM()")
+    suspend fun getAllSongsRandom(): List<Song>
+
     @Query("SELECT count(*) FROM songs")
     suspend fun getSongCount(): Int
 

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -75,6 +75,12 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun shuffleSongs() {
+        viewModelScope.launch {
+            _songs.value = songDao.getAllSongsRandom()
+        }
+    }
+
     fun synchronizeDatabaseAndImages(recheckUpdate: Boolean, onComplete: (Boolean) -> Unit) {
         viewModelScope.launch(Dispatchers.IO) {
             try {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModelProvider
@@ -375,6 +376,12 @@ fun SearchBar(viewModel: SongViewModel) {
                         tint = Color.Gray,
                         modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
                     )
+                }
+            } else {
+                IconButton(onClick = {
+                    viewModel.shuffleSongs()
+                }) {
+                    Text("\uD83D\uDD00", fontSize = 18.sp, color = Color.Gray)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- show a shuffle button when the search field is empty
- shuffle songs in the view model using a new DAO query

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc69d150c8322b1c53c2054788976