### PR TITLE
Add shuffle icon and shuffle favorites

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/MainActivity.kt
@@ -344,7 +344,7 @@ fun ProgressOverlay() {
 }
 
 @Composable
-fun SearchBar(viewModel: SongViewModel) {
+fun SearchBar(viewModel: SongViewModel, onShuffle: (() -> Unit)? = null) {
     OutlinedTextField(
         value = viewModel.searchQuery.value,
         onValueChange = {
@@ -379,9 +379,14 @@ fun SearchBar(viewModel: SongViewModel) {
                 }
             } else {
                 IconButton(onClick = {
-                    viewModel.shuffleSongs()
+                    onShuffle?.invoke() ?: viewModel.shuffleSongs()
                 }) {
-                    Text("\uD83D\uDD00", fontSize = 18.sp, color = Color.Gray)
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_shuffle),
+                        contentDescription = "Shuffle",
+                        tint = Color.Gray,
+                        modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
+                    )
                 }
             }
         }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListSongsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListSongsScreen.kt
@@ -108,7 +108,7 @@ fun FavoriteListSongsScreen(
                         .padding(horizontal = dimensionResource(id = R.dimen.spacing_medium))
                         .offset(y = -12.dp)
                 ) {
-                    SearchBar(viewModel)
+                    SearchBar(viewModel, onShuffle = { songsInList = songsInList.shuffled() })
                 }
             }
         }

--- a/app/src/main/res/drawable/ic_shuffle.xml
+++ b/app/src/main/res/drawable/ic_shuffle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/textColor">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10,3v1.79L15.83,10H20V8h-4.17L10,3zM4,6v2h4.17l2,2H7v6h2v-4.17l5.83,5.83H20v-2h-3.17l-7-7V3H4z" />
+</vector>


### PR DESCRIPTION
## Summary
- replace emoji-based shuffle button with reusable shuffle icon
- allow SearchBar to accept custom shuffle actions
- shuffle favorite list songs using new SearchBar hook

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc5bbc2483228b72e74f64fc848f