### PR TITLE
Adjust chords viewer orientation based on tab image dimensions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,7 +44,6 @@
             </intent-filter>
         </activity>
         <activity android:name=".ui.ChordsViewerActivity"
-            android:screenOrientation="userLandscape"
             android:theme="@style/Theme.CircleSongArchive"/>
         <activity android:name=".ui.LyricsViewerActivity"
             android:theme="@style/Theme.CircleSongArchive"/>


### PR DESCRIPTION
## Summary
- remove the manifest requirement that the chords viewer always uses landscape orientation
- inspect the tab image dimensions and request landscape mode only when the image is wider than tall
- simplify bitmap loading so portrait-oriented tabs remain upright

## Testing
- ./gradlew lint *(fails: plugin com.android.application:8.13.0 could not be resolved in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3131784e88322a04603e4155ec700