### PR TITLE
Handle remote lyrics for Y-prefixed IDs

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
@@ -105,10 +105,11 @@ class LyricsViewerActivity : AppCompatActivity() {
             val songId: String? = intent.getStringExtra("SONG_ID")
             val lyrics: String? = intent.getStringExtra("LYRICS")?.replace("|", "")
             val lyricsShort: String? = intent.getStringExtra("LYRICS_SHORT")?.replace("|", "")
-            if (songId != null) {
+            val fetchSongId = songId?.takeIf { it.isNotBlank() && !it.startsWith("Y", ignoreCase = true) }
+            if (fetchSongId != null) {
                 val songDao = AppDatabase.getDatabase(application).songDao()
                 lifecycleScope.launch {
-                    val fetchedSong = withContext(Dispatchers.IO) { songDao.getSongById(songId) }
+                    val fetchedSong = withContext(Dispatchers.IO) { songDao.getSongById(fetchSongId) }
                     updateUI(fetchedSong, lyrics, lyricsShort, displayStyle)
                 }
             } else {


### PR DESCRIPTION
## Summary
- stop resolving shared lyrics from the database when the provided song id starts with "Y"
- allow clients to display the transmitted lyrics payload for those ids

## Testing
- ./gradlew test *(fails: com.android.application plugin 8.13.0 not available in the offline build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d31eda20c483229b2b31c3211a9286