### PR TITLE
Enable cloning remote songs to local entries from viewer

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -101,6 +101,47 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    fun cloneSongToLocal(
+        originalSong: Song,
+        title: String,
+        lyrics: String,
+        lyricsPaged: String?,
+        localTabUri: String?,
+        onResult: (Song) -> Unit = {},
+    ) {
+        viewModelScope.launch {
+            val clonedSong = withContext(Dispatchers.IO) {
+                val newId = generateNextLocalSongId()
+                val trimmedTitle = title.trim()
+                val trimmedLyrics = lyrics.trim()
+                val sanitizedLyricsPaged = sanitizeLyricsPaged(lyricsPaged)
+                val sanitizedLocalTab = localTabUri?.takeIf { it.isNotBlank() }
+                val finalTabFilename = sanitizedLocalTab?.let { LocalTabUtils.encodeLocalTab(it) } ?: originalSong.tabfilename
+
+                val newSong = originalSong.copy(
+                    id = newId,
+                    title = trimmedTitle,
+                    lyrics = trimmedLyrics,
+                    lyricsShort = null,
+                    lyricsPaged = sanitizedLyricsPaged,
+                    tabfilename = finalTabFilename,
+                    mp3filename = originalSong.mp3filename,
+                    mp3filename2 = originalSong.mp3filename2,
+                    author = originalSong.author,
+                    keywords = originalSong.keywords,
+                    title_normalized = normalizeForSearch(trimmedTitle),
+                    lyrics_normalized = normalizeForSearch(trimmedLyrics),
+                    author_normalized = normalizeForSearch(originalSong.author),
+                    keywords_normalized = normalizeForSearch(originalSong.keywords)
+                )
+                songDao.insertSong(newSong)
+                newSong
+            }
+            refreshSongsList()
+            onResult(clonedSong)
+        }
+    }
+
     fun updateLocalSong(
         songId: String,
         title: String,

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/ViewerControlButtons.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/ViewerControlButtons.kt
@@ -69,7 +69,7 @@ fun ViewerControlButtons(
     onShowMeaningChange: (Boolean) -> Unit,
     onDisplayLyricsPage: (String?) -> Unit,
     onClose: () -> Unit,
-    onEditLocalSong: ((Song) -> Unit)? = null,
+    onEditSong: ((Song) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
@@ -295,9 +295,9 @@ fun ViewerControlButtons(
                         Spacer(modifier = Modifier.width(dimensionResource(id = R.dimen.spacing_medium)))
                     }
 
-                    if (onEditLocalSong != null && song?.id?.startsWith("Y") == true) {
+                    if (onEditSong != null && song != null) {
                         IconButton(
-                            onClick = { onEditLocalSong.invoke(song) },
+                            onClick = { onEditSong.invoke(song) },
                             modifier = Modifier
                                 .background(
                                     Brush.verticalGradient(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="edit_song">Edit song</string>
     <string name="song_title">Title</string>
     <string name="song_lyrics">Lyrics</string>
+    <string name="song_lyrics_long">Lyrics (long)</string>
     <string name="song_lyrics_paged">Lyrics (paged)</string>
     <string name="song_tab_file">Chord file</string>
     <string name="select_tab_file">Select chord file</string>


### PR DESCRIPTION
## Summary
- show the edit button for remote songs and open a clone dialog that creates a local copy before saving
- extend the local song dialog to preview long lyrics and display existing remote tab filenames
- add a SongViewModel helper that clones remote songs into local entries while keeping original metadata

## Testing
- ./gradlew test *(fails: missing Android SDK / outdated KSP in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b1f921748322b01781df386f82cf