### PR TITLE
Add OCR integration for local tab images

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,4 +74,7 @@ dependencies {
 
     // Nearby Connection
     implementation (libs.play.services.nearby)
+
+    // ML Kit OCR
+    implementation(libs.mlkit.text.recognition)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,10 @@
     <string name="select_tab_file">Select chord file</string>
     <string name="remove_tab_file">Remove chord file</string>
     <string name="no_tab_file_selected">No chord file selected</string>
+    <string name="ocr_status_in_progress">Scanning text from image…</string>
+    <string name="ocr_status_success">Lyrics filled from image</string>
+    <string name="ocr_status_no_text">No text detected in selected image</string>
+    <string name="ocr_status_failed">Couldn’t extract text from image</string>
     <string name="delete_song">Delete song</string>
     <string name="confirm_delete_song">Delete this song?</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ uiToolingPreviewAndroid = "1.9.1"
 foundationLayoutAndroid = "1.9.1"
 appcompat = "1.7.1"
 materialVersion = "1.13.0"
+mlkitTextRecognition = "16.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -47,6 +48,7 @@ androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "u
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "materialVersion" }
+mlkit-text-recognition = { module = "com.google.mlkit:text-recognition", version.ref = "mlkitTextRecognition" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- integrate Google ML Kit Text Recognition to scan selected tab images and populate lyrics in the local song dialog
- surface OCR status messaging and manage lifecycle of the recognizer when selecting or clearing tab files
- add the ML Kit dependency and supporting string resources for OCR feedback

## Testing
- `./gradlew lint` *(fails: Android SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d541dc31c88322a30969a3ed770ff8