### PR TITLE
Add camera capture option for tab files

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
@@ -1,8 +1,12 @@
 package de.jeisfeld.songarchive.ui
 
+import android.content.ContentValues
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
@@ -74,6 +78,7 @@ fun LocalSongDialog(
         )
     }
     var showDeleteConfirmation by remember { mutableStateOf(false) }
+    var pendingCameraUri by remember { mutableStateOf<Uri?>(null) }
 
     val coroutineScope = rememberCoroutineScope()
     val cloudVisionClient = remember { FirebaseCloudVisionClient() }
@@ -119,6 +124,27 @@ fun LocalSongDialog(
     }
 
     val scrollState = rememberScrollState()
+
+    val takePictureLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { success ->
+            val capturedUri = pendingCameraUri
+            if (success && capturedUri != null) {
+                val uriString = capturedUri.toString()
+                selectedTabUri = uriString
+                selectedTabDisplayName =
+                    LocalTabUtils.getDisplayName(context, uriString)
+                        ?: capturedUri.lastPathSegment.orEmpty()
+                ocrStatusResId = null
+                startOcrIfNeeded(uriString)
+            } else if (!success && capturedUri != null) {
+                try {
+                    context.contentResolver.delete(capturedUri, null, null)
+                } catch (_: SecurityException) {
+                    // Ignore if we cannot delete the placeholder entry
+                }
+            }
+            pendingCameraUri = null
+        }
 
     val openDocumentLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
@@ -253,6 +279,21 @@ fun LocalSongDialog(
                             }
                         }
                         TextButton(
+                            onClick = {
+                                val captureUri = createImageCaptureUri(context)
+                                if (captureUri != null) {
+                                    pendingCameraUri = captureUri
+                                    ocrStatusResId = null
+                                    takePictureLauncher.launch(captureUri)
+                                } else {
+                                    ocrStatusResId = R.string.ocr_status_failed
+                                }
+                            },
+                            contentPadding = buttonContentPadding
+                        ) {
+                            Text(text = stringResource(id = R.string.capture_tab_photo))
+                        }
+                        TextButton(
                             onClick = { openDocumentLauncher.launch(arrayOf("image/*")) },
                             contentPadding = buttonContentPadding
                         ) {
@@ -311,6 +352,20 @@ private fun readImageBytes(context: Context, uri: Uri): ByteArray {
     return context.contentResolver.openInputStream(uri)?.use { inputStream ->
         inputStream.readBytes()
     } ?: throw IllegalStateException("Unable to read image bytes for $uri")
+}
+
+private fun createImageCaptureUri(context: Context): Uri? {
+    val contentValues = ContentValues().apply {
+        put(MediaStore.MediaColumns.DISPLAY_NAME, "SongArchive_${System.currentTimeMillis()}.jpg")
+        put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            put(
+                MediaStore.Images.Media.RELATIVE_PATH,
+                Environment.DIRECTORY_PICTURES + "/SongArchive"
+            )
+        }
+    }
+    return context.contentResolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
 }
 
 private fun filterChordOnlyLines(text: String): String {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
@@ -277,21 +277,22 @@ fun LocalSongDialog(
                             ) {
                                 Text(text = stringResource(id = R.string.remove_tab_file))
                             }
-                        }
-                        TextButton(
-                            onClick = {
-                                val captureUri = createImageCaptureUri(context)
-                                if (captureUri != null) {
-                                    pendingCameraUri = captureUri
-                                    ocrStatusResId = null
-                                    takePictureLauncher.launch(captureUri)
-                                } else {
-                                    ocrStatusResId = R.string.ocr_status_failed
-                                }
-                            },
-                            contentPadding = buttonContentPadding
-                        ) {
-                            Text(text = stringResource(id = R.string.capture_tab_photo))
+                        } else {
+                            TextButton(
+                                onClick = {
+                                    val captureUri = createImageCaptureUri(context)
+                                    if (captureUri != null) {
+                                        pendingCameraUri = captureUri
+                                        ocrStatusResId = null
+                                        takePictureLauncher.launch(captureUri)
+                                    } else {
+                                        ocrStatusResId = R.string.ocr_status_failed
+                                    }
+                                },
+                                contentPadding = buttonContentPadding
+                            ) {
+                                Text(text = stringResource(id = R.string.capture_tab_photo))
+                            }
                         }
                         TextButton(
                             onClick = { openDocumentLauncher.launch(arrayOf("image/*")) },

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -22,6 +22,7 @@
     <string name="song_tab_file">Akkorddatei</string>
     <string name="select_tab_file">Akkorddatei\nauswählen</string>
     <string name="remove_tab_file">Akkorddatei\nentfernen</string>
+    <string name="capture_tab_photo">Foto aufnehmen</string>
     <string name="no_tab_file_selected">Keine Akkorddatei ausgewählt</string>
     <string name="ocr_status_in_progress">Scanne Text aus Bild…</string>
     <string name="ocr_status_success">Liedtext aus Bild gefüllt</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="song_tab_file">Chord file</string>
     <string name="select_tab_file">Select chord file</string>
     <string name="remove_tab_file">Remove chord file</string>
+    <string name="capture_tab_photo">Take photo</string>
     <string name="no_tab_file_selected">No chord file selected</string>
     <string name="ocr_status_in_progress">Scanning text from image…</string>
     <string name="ocr_status_success">Lyrics filled from image</string>


### PR DESCRIPTION
## Summary
- add a camera capture button to the local song dialog so users can take a photo for chord tabs
- automatically adopt the captured image as the selected tab file and trigger OCR like manual selection
- store captured images in the device pictures directory under a SongArchive folder

## Testing
- ./gradlew lint *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c696680c8322964bf53d6522c81b