### PR TITLE
Add camera capture option for tab images

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,9 @@
     <string name="song_tab_file">Chord file</string>
     <string name="select_tab_file">Select chord file</string>
     <string name="remove_tab_file">Remove chord file</string>
+    <string name="capture_tab_photo">Take photo</string>
+    <string name="captured_tab_photo_default_name">New photo</string>
+    <string name="camera_launch_failed">Couldn’t open camera</string>
     <string name="no_tab_file_selected">No chord file selected</string>
     <string name="ocr_status_in_progress">Scanning text from image…</string>
     <string name="ocr_status_success">Lyrics filled from image</string>


### PR DESCRIPTION
## Summary
- add camera permission and button to capture a chord photo directly from the Add Song dialog
- persist captured images to the Photos directory, reuse OCR pipeline, and populate the selected tab field automatically
- add supporting strings and messaging for the new capture flow

## Testing
- ./gradlew lint *(fails: SDK location not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c696680c8322964bf53d6522c81b