### PR TITLE
Add basic auth credentials for secure downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 local.properties
 /app-release.aab
 app/firebase.properties
+app/auth.properties

--- a/app/auth.properties.example
+++ b/app/auth.properties.example
@@ -1,0 +1,4 @@
+# Copy this file to auth.properties and replace the placeholder values
+# with the credentials for the basic authentication protected endpoints.
+basicAuthUsername=yourUsername
+basicAuthPassword=yourPassword

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,14 @@ if (firebasePropertiesFile.exists()) {
 val firebaseCloudVisionApiKey =
     firebaseProperties.getProperty("firebaseCloudVisionApiKey", "")
 
+val authPropertiesFile = project.layout.projectDirectory.file("auth.properties").asFile
+val authProperties = Properties()
+if (authPropertiesFile.exists()) {
+    authPropertiesFile.inputStream().use(authProperties::load)
+}
+val basicAuthUsername = authProperties.getProperty("basicAuthUsername", "")
+val basicAuthPassword = authProperties.getProperty("basicAuthPassword", "")
+
 android {
     namespace = "de.jeisfeld.songarchive"
     compileSdk = 35
@@ -32,6 +40,15 @@ android {
             .replace("\\", "\\\\")
             .replace("\"", "\\\"")
         buildConfigField("String", "FIREBASE_CLOUD_VISION_API_KEY", "\"$escapedApiKey\"")
+
+        val escapedUsername = basicAuthUsername
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+        val escapedPassword = basicAuthPassword
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+        buildConfigField("String", "BASIC_AUTH_USERNAME", "\"$escapedUsername\"")
+        buildConfigField("String", "BASIC_AUTH_PASSWORD", "\"$escapedPassword\"")
     }
 
     buildTypes {

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileInputStream
@@ -37,7 +36,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
     private val favoriteDao = AppDatabase.getDatabase(application).favoriteListDao()
     private val _songs = MutableStateFlow<List<Song>>(emptyList())
     val songs: StateFlow<List<Song>> = _songs
-    private val client = OkHttpClient()
+    private val client = RetrofitClient.httpClient
     var searchQuery = mutableStateOf("")
     var initState = MutableLiveData<Int>(0)
     var checkUpdateResponse: CheckUpdateResponse? = null
@@ -257,7 +256,7 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
                 favoriteDao.insertSongs(existingFavorites.filter { validSongIds.contains(it.songId) })
 
                 // Step 2: Download and Extract Images
-                val success = downloadAndExtractZip(getApplication(), "https://heilsame-lieder.de/download_chords.php")
+                val success = downloadAndExtractZip(getApplication(), "https://heilsame-lieder.de/admin/download_chords.php")
 
                 if (success) {
                     if (recheckUpdate) {

--- a/app/src/main/java/de/jeisfeld/songarchive/sync/ApiService.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/sync/ApiService.kt
@@ -1,12 +1,13 @@
 package de.jeisfeld.songarchive.sync
 
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface ApiService {
-    @GET("download_data.php")
+    @GET("admin/download_data.php")
     suspend fun fetchAllData(@Query("user") user: String? = null): SyncResponse
 
     @GET("check_update.php")
@@ -14,12 +15,28 @@ interface ApiService {
 }
 
 object RetrofitClient {
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val requestBuilder = chain.request().newBuilder()
+                BasicAuthProvider.authorizationHeader?.let { header ->
+                    requestBuilder.addHeader("Authorization", header)
+                }
+                chain.proceed(requestBuilder.build())
+            }
+            .build()
+    }
+
     val api: ApiService by lazy {
         Retrofit.Builder()
             .baseUrl("https://heilsame-lieder.de/")
+            .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
             .create(ApiService::class.java)
     }
+
+    val httpClient: OkHttpClient
+        get() = okHttpClient
 }
 

--- a/app/src/main/java/de/jeisfeld/songarchive/sync/BasicAuthProvider.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/sync/BasicAuthProvider.kt
@@ -1,0 +1,22 @@
+package de.jeisfeld.songarchive.sync
+
+import android.util.Base64
+import android.util.Log
+import de.jeisfeld.songarchive.BuildConfig
+
+object BasicAuthProvider {
+    private const val TAG = "BasicAuthProvider"
+
+    val authorizationHeader: String?
+        get() {
+            val username = BuildConfig.BASIC_AUTH_USERNAME
+            val password = BuildConfig.BASIC_AUTH_PASSWORD
+            if (username.isBlank() || password.isBlank()) {
+                Log.w(TAG, "Basic authentication credentials are missing.")
+                return null
+            }
+            val credentials = "$username:$password"
+            val encoded = Base64.encodeToString(credentials.toByteArray(), Base64.NO_WRAP)
+            return "Basic $encoded"
+        }
+}


### PR DESCRIPTION
## Summary
- add a reusable OkHttp client that injects basic auth credentials for protected endpoints
- update download_data.php and download_chords.php calls to use the /admin paths
- load credentials from a gitignored auth.properties file and provide an example template

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71ad0f7648322afb3b7214287460f