### PR TITLE
Add server upload option for local songs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
 
     // Jetpack Compose UI
     implementation(libs.ui)
+    implementation(libs.androidx.runtime.livedata)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
 
     // Room für SQLite-Datenbank

--- a/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/SongViewModel.kt
@@ -197,10 +197,10 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
                 try {
                     val sanitizedSong = buildLocalSong(songId, title, lyrics, lyricsPaged, localTabUri)
                     val existingSong = songDao.getSongById(songId)
-                    val preservedRemoteTab = existingSong?.tabfilename?.takeIf { tab -> !LocalTabUtils.isLocalTab(tab) }
-                    val mergedTabFilename = sanitizedSong.tabfilename ?: preservedRemoteTab
-                    val finalLyricsShort = sanitizedSong.lyricsShort ?: existingSong?.lyricsShort
-                    val finalLyricsPaged = sanitizedSong.lyricsPaged ?: existingSong?.lyricsPaged
+                    val finalLyricsShort = sanitizedSong.lyricsShort ?: existingSong?.lyricsShort?.trim()
+                    val finalLyricsPaged = sanitizedSong.lyricsPaged ?: existingSong?.lyricsPaged?.trim()
+                    val finalAuthor = existingSong?.author?.trim()
+                    val finalKeywords = existingSong?.keywords?.trim()
 
                     val formBodyBuilder = FormBody.Builder()
                         .add("id", songId)
@@ -213,19 +213,10 @@ class SongViewModel(application: Application) : AndroidViewModel(application) {
                     finalLyricsPaged?.takeIf { it.isNotBlank() }?.let {
                         formBodyBuilder.add("lyrics_paged", it)
                     }
-                    mergedTabFilename?.takeIf { it.isNotBlank() && !LocalTabUtils.isLocalTab(it) }?.let {
-                        formBodyBuilder.add("tabfilename", it)
-                    }
-                    existingSong?.mp3filename?.takeIf { it.isNotBlank() }?.let {
-                        formBodyBuilder.add("mp3filename", it)
-                    }
-                    existingSong?.mp3filename2?.takeIf { it.isNotBlank() }?.let {
-                        formBodyBuilder.add("mp3filename2", it)
-                    }
-                    existingSong?.author?.takeIf { it.isNotBlank() }?.let {
+                    finalAuthor?.takeIf { it.isNotBlank() }?.let {
                         formBodyBuilder.add("author", it)
                     }
-                    existingSong?.keywords?.takeIf { it.isNotBlank() }?.let {
+                    finalKeywords?.takeIf { it.isNotBlank() }?.let {
                         formBodyBuilder.add("keywords", it)
                     }
 

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
@@ -60,6 +60,7 @@ fun LocalSongDialog(
     onConfirm: (String, String, String?, String?) -> Unit,
     onDelete: (() -> Unit)? = null,
     onUpload: ((String, String, String?, String?) -> Unit)? = null,
+    uploadEnabled: Boolean = false,
 ) {
     var title by remember { mutableStateOf(TextFieldValue(initialTitle)) }
     var lyrics by remember { mutableStateOf(TextFieldValue(initialLyrics)) }
@@ -201,7 +202,7 @@ fun LocalSongDialog(
         )
     }
 
-    if (showUploadConfirmation) {
+    if (showUploadConfirmation && uploadEnabled) {
         AlertDialog(
             onDismissRequest = { showUploadConfirmation = false },
             title = { Text(text = stringResource(id = R.string.upload_song_title)) },
@@ -210,7 +211,7 @@ fun LocalSongDialog(
                 TextButton(
                     onClick = {
                         showUploadConfirmation = false
-                        if (trimmedTitle.isNotEmpty() && trimmedLyrics.isNotEmpty()) {
+                        if (uploadEnabled && trimmedTitle.isNotEmpty() && trimmedLyrics.isNotEmpty()) {
                             onUpload?.invoke(
                                 trimmedTitle,
                                 trimmedLyrics,
@@ -237,11 +238,11 @@ fun LocalSongDialog(
         onDismissRequest = onDismiss,
         title = {
             val titleText = stringResource(id = if (isEditing) R.string.edit_song else R.string.add_song)
-            val titleModifier = if (isEditing && onUpload != null) {
-                Modifier.pointerInput(trimmedTitle, trimmedLyrics) {
+            val titleModifier = if (isEditing && onUpload != null && uploadEnabled) {
+                Modifier.pointerInput(trimmedTitle, trimmedLyrics, uploadEnabled) {
                     detectTapGestures(
                         onLongPress = {
-                            if (trimmedTitle.isNotEmpty() && trimmedLyrics.isNotEmpty()) {
+                            if (uploadEnabled && trimmedTitle.isNotEmpty() && trimmedLyrics.isNotEmpty()) {
                                 showUploadConfirmation = true
                             }
                         }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -193,6 +194,9 @@ fun LyricsViewerScreen(
     var showEditDialog by remember { mutableStateOf(false) }
     var showCloneDialog by remember { mutableStateOf(false) }
     var songForClone by remember { mutableStateOf<Song?>(null) }
+
+    val pluginVerifiedState = viewModel?.pluginVerified?.observeAsState(false)
+    val isPluginVerified = pluginVerifiedState?.value ?: false
 
     LaunchedEffect(
         lyricsPageOverride,
@@ -406,7 +410,8 @@ fun LyricsViewerScreen(
                     updatedLyricsPaged,
                     updatedTabUri
                 )
-            }
+            },
+            uploadEnabled = isPluginVerified
         )
     }
 }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
@@ -397,6 +397,15 @@ fun LyricsViewerScreen(
                     showEditDialog = false
                     onClose()
                 }
+            },
+            onUpload = { updatedTitle, updatedLyrics, updatedLyricsPaged, updatedTabUri ->
+                viewModel.uploadLocalSongToServer(
+                    currentSong!!.id,
+                    updatedTitle,
+                    updatedLyrics,
+                    updatedLyricsPaged,
+                    updatedTabUri
+                )
             }
         )
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -31,6 +31,11 @@
     <string name="ocr_status_missing_api_key">Bitte Firebase Cloud Vision API-Schlüssel hinterlegen, um OCR zu aktivieren</string>
     <string name="delete_song">Lied löschen</string>
     <string name="confirm_delete_song">Dieses Lied löschen?</string>
+    <string name="upload">Hochladen</string>
+    <string name="upload_song_title">Lied hochladen</string>
+    <string name="confirm_upload_song">Dieses Lied auf den Server hochladen?</string>
+    <string name="upload_song_success">Lied erfolgreich auf den Server hochgeladen.</string>
+    <string name="upload_song_failed">Hochladen des Liedes fehlgeschlagen.</string>
 
     <string name="sync">Synchronisieren</string>
     <string name="network_connection">Netzwerkverbindung</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,11 @@
     <string name="ocr_status_missing_api_key">Add Firebase Cloud Vision API key to enable OCR</string>
     <string name="delete_song">Delete song</string>
     <string name="confirm_delete_song">Delete this song?</string>
+    <string name="upload">Upload</string>
+    <string name="upload_song_title">Upload song</string>
+    <string name="confirm_upload_song">Upload this song to the server?</string>
+    <string name="upload_song_success">Song uploaded to server.</string>
+    <string name="upload_song_failed">Song upload failed.</string>
 
     <string name="sync">Sync</string>
     <string name="network_connection">Network Connection</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ playServicesNearby = "19.3.0"
 retrofit = "3.0.0"
 roomRuntime = "2.8.0"
 ui = "1.9.1"
+runtimeLivedata = "1.9.1"
 workRuntimeKtx = "2.10.4"
 ksp = "2.2.0-2.0.2"
 uiToolingPreviewAndroid = "1.9.1"
@@ -44,6 +45,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 play-services-nearby = { module = "com.google.android.gms:play-services-nearby", version.ref = "playServicesNearby" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 ui = { module = "androidx.compose.ui:ui", version.ref = "ui" }
+androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 androidx-foundation-layout-android = { group = "androidx.compose.foundation", name = "foundation-layout-android", version.ref = "foundationLayoutAndroid" }


### PR DESCRIPTION
## Summary
- enable a long-press gesture on the local "Edit song" dialog title to trigger an upload confirmation flow
- add localized strings and wire the dialog to invoke a new upload callback when confirmed
- implement `SongViewModel.uploadLocalSongToServer` to POST local song data with Basic Auth and surface the result via toasts
- connect the lyrics viewer edit dialog to the new upload path

## Testing
- `./gradlew :app:assembleDebug` *(fails: Android SDK not configured in CI image and bundled KSP version is incompatible with Kotlin 2.2.20)*

------
https://chatgpt.com/codex/tasks/task_e_68d724de42ac832287e1fbabe2a43728