### PR TITLE
Ensure plugin verification before allowing upload dialog

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LocalSongDialog.kt
@@ -60,6 +60,7 @@ fun LocalSongDialog(
     onConfirm: (String, String, String?, String?) -> Unit,
     onDelete: (() -> Unit)? = null,
     onUpload: ((String, String, String?, String?) -> Unit)? = null,
+    isPluginVerified: Boolean = false,
 ) {
     var title by remember { mutableStateOf(TextFieldValue(initialTitle)) }
     var lyrics by remember { mutableStateOf(TextFieldValue(initialLyrics)) }
@@ -84,6 +85,12 @@ fun LocalSongDialog(
     var showDeleteConfirmation by remember { mutableStateOf(false) }
     var showUploadConfirmation by remember { mutableStateOf(false) }
     var pendingCameraUri by remember { mutableStateOf<Uri?>(null) }
+
+    LaunchedEffect(isPluginVerified) {
+        if (!isPluginVerified) {
+            showUploadConfirmation = false
+        }
+    }
 
     val coroutineScope = rememberCoroutineScope()
     val cloudVisionClient = remember { FirebaseCloudVisionClient() }
@@ -201,7 +208,7 @@ fun LocalSongDialog(
         )
     }
 
-    if (showUploadConfirmation) {
+    if (showUploadConfirmation && isPluginVerified) {
         AlertDialog(
             onDismissRequest = { showUploadConfirmation = false },
             title = { Text(text = stringResource(id = R.string.upload_song_title)) },
@@ -237,7 +244,7 @@ fun LocalSongDialog(
         onDismissRequest = onDismiss,
         title = {
             val titleText = stringResource(id = if (isEditing) R.string.edit_song else R.string.add_song)
-            val titleModifier = if (isEditing && onUpload != null) {
+            val titleModifier = if (isEditing && onUpload != null && isPluginVerified) {
                 Modifier.pointerInput(trimmedTitle, trimmedLyrics) {
                     detectTapGestures(
                         onLongPress = {

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/LyricsViewerActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -33,6 +34,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.pointerInteropFilter
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.TextStyle
@@ -182,6 +184,13 @@ fun LyricsViewerScreen(
     var startPadding = if (isLandscape) 0f else 8f
 
     val textMeasurer = TextMeasurer()
+    val context = LocalContext.current
+    val pluginVerifiedState = viewModel?.pluginVerified?.observeAsState(false)
+    val pluginVerified = pluginVerifiedState?.value ?: false
+
+    LaunchedEffect(viewModel, context) {
+        viewModel?.sendPluginVerificationBroadcast(context)
+    }
 
     var fontSize by remember { mutableStateOf(24f) }
     var lineHeight by remember { mutableStateOf(1.3f) }
@@ -406,7 +415,8 @@ fun LyricsViewerScreen(
                     updatedLyricsPaged,
                     updatedTabUri
                 )
-            }
+            },
+            isPluginVerified = pluginVerified
         )
     }
 }


### PR DESCRIPTION
## Summary
- gate the upload-to-server dialog behind the plugin verification flag in the local song editor
- observe plugin verification state in the lyrics viewer and trigger verification broadcasts when the screen opens to ensure availability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d73326d9608322a6390f0dca0ee408