### PR TITLE
Add drag-and-drop reordering for favorite lists

### DIFF
--- a/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     entities = [Song::class, Meaning::class, SongMeaning::class, AppMetadata::class, FavoriteList::class, FavoriteListSong::class],
-    version = 15,
+    version = 16,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -69,6 +69,23 @@ abstract class AppDatabase : RoomDatabase() {
             }
         }
 
+        private val MIGRATION_15_16 = object : Migration(15, 16) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE favorite_lists ADD COLUMN position INTEGER NOT NULL DEFAULT 0")
+                database.execSQL(
+                    """
+                        UPDATE favorite_lists
+                        SET position = ordering.new_position
+                        FROM (
+                            SELECT id, ROW_NUMBER() OVER (ORDER BY id) - 1 AS new_position
+                            FROM favorite_lists
+                        ) AS ordering
+                        WHERE favorite_lists.id = ordering.id
+                    """.trimIndent()
+                )
+            }
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -76,13 +93,12 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "songs.db"
                 )
-                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15)
+                    .addMigrations(MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16)
                     .build()
                 INSTANCE = instance
                 instance
             }
         }
     }
-
 }
 

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteList.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteList.kt
@@ -7,5 +7,6 @@ import androidx.room.PrimaryKey
 data class FavoriteList(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     val name: String,
-    val isSorted: Boolean = false
+    val isSorted: Boolean = false,
+    val position: Int = 0
 )

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListDao.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListDao.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface FavoriteListDao {
-    @Query("SELECT * FROM favorite_lists ORDER BY id")
+    @Query("SELECT * FROM favorite_lists ORDER BY position, id")
     fun getAll(): Flow<List<FavoriteList>>
 
     @Query("SELECT * FROM favorite_lists WHERE id = :id")
@@ -30,6 +30,12 @@ interface FavoriteListDao {
 
     @Delete
     suspend fun delete(list: FavoriteList)
+
+    @Query("SELECT COALESCE(MAX(position), -1) FROM favorite_lists")
+    suspend fun getMaxListPosition(): Int
+
+    @Query("UPDATE favorite_lists SET position = :position WHERE id = :listId")
+    suspend fun updateListPosition(listId: Int, position: Int)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertSong(entry: FavoriteListSong)

--- a/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListViewModel.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/db/FavoriteListViewModel.kt
@@ -22,7 +22,10 @@ class FavoriteListViewModel(application: Application) : AndroidViewModel(applica
     )
 
     fun addList(name: String, sorted: Boolean = false) {
-        viewModelScope.launch { dao.insert(FavoriteList(name = name, isSorted = sorted)) }
+        viewModelScope.launch {
+            val maxPosition = dao.getMaxListPosition()
+            dao.insert(FavoriteList(name = name, isSorted = sorted, position = maxPosition + 1))
+        }
     }
 
     suspend fun addListWithSongs(name: String, songIds: List<String>, sorted: Boolean = false): List<String> {
@@ -36,7 +39,8 @@ class FavoriteListViewModel(application: Application) : AndroidViewModel(applica
                 missing.add(id)
             }
         }
-        val listId = dao.insert(FavoriteList(name = name, isSorted = sorted)).toInt()
+        val maxPosition = dao.getMaxListPosition()
+        val listId = dao.insert(FavoriteList(name = name, isSorted = sorted, position = maxPosition + 1)).toInt()
         dao.insertSongs(valid.mapIndexed { index, songId -> FavoriteListSong(listId, songId, index) })
         return missing
     }
@@ -52,7 +56,8 @@ class FavoriteListViewModel(application: Application) : AndroidViewModel(applica
                 missing.add(entry.songId)
             }
         }
-        val listId = dao.insert(FavoriteList(name = name, isSorted = sorted)).toInt()
+        val maxPosition = dao.getMaxListPosition()
+        val listId = dao.insert(FavoriteList(name = name, isSorted = sorted, position = maxPosition + 1)).toInt()
         dao.insertSongs(validEntries.map { it.copy(listId = listId) })
         return missing
     }
@@ -149,6 +154,14 @@ class FavoriteListViewModel(application: Application) : AndroidViewModel(applica
         viewModelScope.launch {
             orderedSongIds.forEachIndexed { index, songId ->
                 dao.updatePosition(listId, songId, index)
+            }
+        }
+    }
+
+    fun updateListPositions(orderedListIds: List<Int>) {
+        viewModelScope.launch {
+            orderedListIds.forEachIndexed { index, listId ->
+                dao.updateListPosition(listId, index)
             }
         }
     }

--- a/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsScreen.kt
+++ b/app/src/main/java/de/jeisfeld/songarchive/ui/favoritelists/FavoriteListsScreen.kt
@@ -4,18 +4,21 @@ import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -24,17 +27,24 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.zIndex
 import de.jeisfeld.songarchive.R
 import de.jeisfeld.songarchive.db.FavoriteList
 import de.jeisfeld.songarchive.db.FavoriteListViewModel
@@ -43,10 +53,10 @@ import de.jeisfeld.songarchive.network.PeerConnectionMode
 import de.jeisfeld.songarchive.network.PeerConnectionService
 import de.jeisfeld.songarchive.network.PeerConnectionViewModel
 import de.jeisfeld.songarchive.ui.theme.AppColors
-import androidx.compose.runtime.rememberCoroutineScope
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -57,6 +67,13 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
 
     val lists by viewModel.lists.collectAsState()
     val context = LocalContext.current
+
+    val orderedLists = remember { mutableStateListOf<FavoriteList>() }
+    LaunchedEffect(lists) {
+        orderedLists.clear()
+        orderedLists.addAll(lists)
+    }
+    var draggedId by remember { mutableStateOf<Int?>(null) }
 
     Scaffold(
         topBar = {
@@ -94,12 +111,58 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
                 .padding(horizontal = dimensionResource(id = R.dimen.spacing_medium))
         ) {
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                items(lists) { list ->
+                itemsIndexed(orderedLists, key = { _, item -> item.id }) { _, list ->
                     val scope = rememberCoroutineScope()
+                    var offsetY by remember { mutableStateOf(0f) }
+                    var rowHeight by remember { mutableStateOf(1) }
+                    val isDragging = draggedId == list.id
+
+                    fun finalizeDrag(updateDb: Boolean) {
+                        offsetY = 0f
+                        draggedId = null
+                        if (updateDb) {
+                            viewModel.updateListPositions(orderedLists.map { it.id })
+                        }
+                    }
+
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .offset { IntOffset(0, offsetY.roundToInt()) }
+                            .zIndex(if (isDragging) 1f else 0f)
+                            .pointerInput(orderedLists.size) {
+                                detectDragGesturesAfterLongPress(
+                                    onDragStart = {
+                                        draggedId = list.id
+                                        offsetY = 0f
+                                    },
+                                    onDrag = { change, dragAmount ->
+                                        if (draggedId != list.id) return@detectDragGesturesAfterLongPress
+                                        change.consume()
+                                        offsetY += dragAmount.y
+                                        val itemHeight = rowHeight.takeIf { it != 0 } ?: 1
+                                        val currentIndex = orderedLists.indexOfFirst { it.id == list.id }
+                                        if (currentIndex == -1) return@detectDragGesturesAfterLongPress
+                                        val targetIndex = (currentIndex + (offsetY / itemHeight).roundToInt()).coerceIn(0, orderedLists.lastIndex)
+                                        if (targetIndex != currentIndex) {
+                                            orderedLists.move(currentIndex, targetIndex)
+                                            offsetY -= (targetIndex - currentIndex) * itemHeight
+                                        }
+                                    },
+                                    onDragEnd = {
+                                        if (draggedId == list.id) {
+                                            finalizeDrag(updateDb = true)
+                                        }
+                                    },
+                                    onDragCancel = {
+                                        if (draggedId == list.id) {
+                                            finalizeDrag(updateDb = false)
+                                        }
+                                    }
+                                )
+                            }
                             .padding(vertical = dimensionResource(id = R.dimen.spacing_vertical_medium))
+                            .onGloballyPositioned { rowHeight = it.size.height }
                             .clickable {
                                 val intent = Intent(context, FavoriteListSongsActivity::class.java).apply {
                                     putExtra("LIST_ID", list.id)
@@ -113,50 +176,65 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
                             Alignment.End
                         )
                     ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_drag_handle),
+                            contentDescription = stringResource(id = R.string.drag_to_reorder),
+                            tint = AppColors.TextColor
+                        )
                         Text(text = list.name, color = AppColors.TextColor, modifier = Modifier.weight(1f))
                         if (PeerConnectionViewModel.peerConnectionMode == PeerConnectionMode.SERVER &&
-                            PeerConnectionViewModel.connectedDevices > 0) {
+                            PeerConnectionViewModel.connectedDevices > 0
+                        ) {
                             IconButton(
                                 onClick = {
-                                scope.launch {
-                                    val entries = withContext(Dispatchers.IO) { viewModel.getSongEntries(list.id) }
-                                    val ids = entries.joinToString(",") { it.entry.songId }
-                                    val payload = org.json.JSONArray().apply {
-                                        entries.sortedBy { it.entry.position }.forEach { entry ->
-                                            put(org.json.JSONObject().apply {
-                                                put("songId", entry.entry.songId)
-                                                put("position", entry.entry.position)
-                                                put("customTitle", entry.entry.customTitle)
-                                            })
+                                    scope.launch {
+                                        val entries = withContext(Dispatchers.IO) { viewModel.getSongEntries(list.id) }
+                                        val ids = entries.joinToString(",") { it.entry.songId }
+                                        val payload = org.json.JSONArray().apply {
+                                            entries.sortedBy { it.entry.position }.forEach { entry ->
+                                                put(org.json.JSONObject().apply {
+                                                    put("songId", entry.entry.songId)
+                                                    put("position", entry.entry.position)
+                                                    put("customTitle", entry.entry.customTitle)
+                                                })
+                                            }
+                                        }.toString()
+                                        val intent = Intent(context, PeerConnectionService::class.java).apply {
+                                            setAction(PeerConnectionAction.SHARE_FAVORITE_LIST.toString())
+                                            putExtra("ACTION", PeerConnectionAction.SHARE_FAVORITE_LIST)
+                                            putExtra("LIST_NAME", list.name)
+                                            putExtra("SONG_IDS", ids)
+                                            putExtra("LIST_SORTED", list.isSorted)
+                                            putExtra("LIST_ENTRIES", payload)
                                         }
-                                    }.toString()
-                                    val intent = Intent(context, PeerConnectionService::class.java).apply {
-                                        setAction(PeerConnectionAction.SHARE_FAVORITE_LIST.toString())
-                                        putExtra("ACTION", PeerConnectionAction.SHARE_FAVORITE_LIST)
-                                        putExtra("LIST_NAME", list.name)
-                                        putExtra("SONG_IDS", ids)
-                                        putExtra("LIST_SORTED", list.isSorted)
-                                        putExtra("LIST_ENTRIES", payload)
+                                        context.startService(intent)
                                     }
-                                    context.startService(intent)
-                                }
-                            },
+                                },
                                 modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
                             ) {
-                                Image(painter = painterResource(id = R.drawable.ic_send), contentDescription = stringResource(id = R.string.share_favorite_list))
+                                Image(
+                                    painter = painterResource(id = R.drawable.ic_send),
+                                    contentDescription = stringResource(id = R.string.share_favorite_list)
+                                )
                             }
                         }
                         IconButton(
                             onClick = { renameTarget = list },
                             modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
                         ) {
-                            Image(painter = painterResource(id = R.drawable.ic_edit), contentDescription = stringResource(id = R.string.rename_favorite_list))
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_edit),
+                                contentDescription = stringResource(id = R.string.rename_favorite_list)
+                            )
                         }
                         IconButton(
                             onClick = { deleteTarget = list },
                             modifier = Modifier.size(dimensionResource(id = R.dimen.icon_size_small))
                         ) {
-                            Image(painter = painterResource(id = R.drawable.ic_delete), contentDescription = stringResource(id = R.string.delete_favorite_list))
+                            Image(
+                                painter = painterResource(id = R.drawable.ic_delete),
+                                contentDescription = stringResource(id = R.string.delete_favorite_list)
+                            )
                         }
                     }
                 }
@@ -172,7 +250,11 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
             title = { Text(stringResource(id = R.string.add_favorite_list)) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(dimensionResource(id = R.dimen.spacing_small))) {
-                    OutlinedTextField(value = name, onValueChange = { name = it }, placeholder = { Text(stringResource(id = R.string.list_name)) })
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        placeholder = { Text(stringResource(id = R.string.list_name)) }
+                    )
                     Row(verticalAlignment = Alignment.CenterVertically) {
                         Checkbox(checked = sorted, onCheckedChange = { sorted = it })
                         Column {
@@ -232,4 +314,10 @@ fun FavoriteListsScreen(viewModel: FavoriteListViewModel, onClose: () -> Unit) {
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text(stringResource(id = R.string.cancel)) } }
         )
     }
+}
+
+private fun <T> MutableList<T>.move(fromIndex: Int, toIndex: Int) {
+    if (fromIndex == toIndex || fromIndex !in indices || toIndex !in indices) return
+    val element = removeAt(fromIndex)
+    add(toIndex, element)
 }


### PR DESCRIPTION
### Motivation
- Favorite lists are currently ordered by creation id and cannot be reordered by the user; make them reorderable via drag-and-drop and persist that order.
- Preserve existing list ordering for existing users by backfilling a persistent `position` column during DB migration.

### Description
- Added a persistent `position` field to the `FavoriteList` entity (`FavoriteList.position`).
- Updated DAO to return lists ordered by `position, id` and added `getMaxListPosition()` and `updateListPosition(...)` methods to manage list ordering.
- Updated `FavoriteListViewModel` to append new lists at `maxPosition + 1` and added `updateListPositions(orderedListIds: List<Int>)` to persist reordered lists.
- Added a Room migration `15 -> 16` that adds the `position` column and backfills it using the existing creation order so existing lists keep their relative order (`AppDatabase` changes).
- Implemented drag-and-drop UI in `FavoriteListsScreen` using `detectDragGesturesAfterLongPress`, a locally mutable `orderedLists` state, a `move` helper, and a finalize step that calls `viewModel.updateListPositions(...)` to persist the new order.

### Testing
- Attempted to compile the app with `./gradlew :app:compileDebugKotlin`; the build could not complete in this environment due to a missing Android SDK (`local.properties` / `ANDROID_HOME`), so automated compilation failed.
- No other automated tests were run in this environment due to the same SDK constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0ce502a3c83229a1503bbb73b70a5)