### PR TITLE
Fix admin add-song modal blank state on DB validation errors

### DIFF
--- a/web/admin/addsong.php
+++ b/web/admin/addsong.php
@@ -26,27 +26,37 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($formValues['id'] === '' || $formValues['title'] === '' || trim($lyricsInput) === '') {
         $errorMessage = 'Please fill in all required fields.';
     } else {
-        $insertSql = 'INSERT INTO songs (id, title, lyrics) VALUES (?, ?, ?)';
-        $insertStmt = $conn->prepare($insertSql);
+        try {
+            $insertSql = 'INSERT INTO songs (id, title, lyrics) VALUES (?, ?, ?)';
+            $insertStmt = $conn->prepare($insertSql);
 
-        if (! $insertStmt) {
-            error_log('Failed to prepare insert statement: ' . $conn->error);
-            $errorMessage = 'Unable to prepare the song for saving.';
-        } else {
-            $insertStmt->bind_param('sss', $formValues['id'], $formValues['title'], $lyricsInput);
-
-            if ($insertStmt->execute()) {
-                $insertSuccess = true;
+            if (! $insertStmt) {
+                error_log('Failed to prepare insert statement: ' . $conn->error);
+                $errorMessage = 'Unable to prepare the song for saving.';
             } else {
-                if ($insertStmt->errno === 1062) {
-                    $errorMessage = 'A song with this ID already exists.';
-                } else {
-                    error_log('Failed to execute insert statement: ' . $insertStmt->error);
-                    $errorMessage = 'Failed to save the song.';
-                }
-            }
+                $insertStmt->bind_param('sss', $formValues['id'], $formValues['title'], $lyricsInput);
 
-            $insertStmt->close();
+                if ($insertStmt->execute()) {
+                    $insertSuccess = true;
+                } else {
+                    if ($insertStmt->errno === 1062) {
+                        $errorMessage = 'A song with this ID already exists.';
+                    } else {
+                        error_log('Failed to execute insert statement: ' . $insertStmt->error);
+                        $errorMessage = 'Failed to save the song.';
+                    }
+                }
+
+                $insertStmt->close();
+            }
+        } catch (Throwable $exception) {
+            $errorCode = method_exists($exception, 'getCode') ? (int) $exception->getCode() : 0;
+            if ($errorCode === 1062) {
+                $errorMessage = 'A song with this ID already exists.';
+            } else {
+                error_log('Failed to save song: ' . $exception->getMessage());
+                $errorMessage = 'Failed to save the song.';
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Submitting invalid data (for example a duplicate `id`) could cause the insert code to throw and abort rendering the PHP page, leaving the admin add-song iframe/modal blank. 
- The aim is to keep the form visible with the entered values and display a friendly error message instead of an empty modal when database errors occur.

### Description
- Wrapped the prepare/execute insert block in `web/admin/addsong.php` with a `try/catch` to prevent uncaught `Throwable` from terminating the response. 
- Added explicit handling for MySQL duplicate-key errors (`1062`) inside the exception path to show the existing message `A song with this ID already exists.`. 
- Kept existing logging for technical failures and preserved the submitted `formValues` so the form re-renders with the user input and an error message.

### Testing
- Ran a PHP syntax check with `php -l web/admin/addsong.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa0210b3b4832297730cd01225bccd)