### PR TITLE
Move include_hidden search flag to POST

### DIFF
--- a/web/js/songbook.js
+++ b/web/js/songbook.js
@@ -46,12 +46,16 @@ async function performSearch(query) {
 	const signal = searchAbortController.signal;
 
 	try {
-		let requestUrl = "/search.php?q=" + encodeURIComponent(query);
+		const requestBody = new URLSearchParams();
 		if (isAdminView()) {
-			requestUrl += "&include_hidden=1";
+			requestBody.set("include_hidden", "1");
 		}
 
-		let response = await fetch(requestUrl, { signal });
+		let response = await fetch("/search.php?q=" + encodeURIComponent(query), {
+			method: "POST",
+			body: requestBody,
+			signal
+		});
 		let songs = await response.json();
 		displayResult(songs);
 	}

--- a/web/search.php
+++ b/web/search.php
@@ -7,7 +7,7 @@ require_once "db_config.php";
 
 // Get query
 $query = isset ( $_GET ['q'] ) ? trim ( $_GET ['q'] ) : "";
-$includeHidden = filter_var ( $_GET ['include_hidden'] ?? false, FILTER_VALIDATE_BOOLEAN );
+$includeHidden = filter_var ( $_POST ['include_hidden'] ?? false, FILTER_VALIDATE_BOOLEAN );
 $applyIdFilter = ! $includeHidden;
 
 // Use regex to check if query is a valid ID (numeric OR numeric + single letter)


### PR DESCRIPTION
### Motivation
- Prevent leaking the admin-only `include_hidden` flag in the query string by moving it out of the URL and into the request body.
- Keep the search `q` parameter as a simple GET value while restricting the admin flag to a POST payload for safer handling.

### Description
- Update `web/js/songbook.js` to build a `URLSearchParams` body and send `include_hidden=1` in the POST body when `isAdminView()` is true, while still sending `q` as a GET parameter to `/search.php`.
- Update `web/search.php` to read `include_hidden` from `$_POST` instead of `$_GET`, preserving the existing behavior when the flag is absent.
- Ensure the endpoint remains compatible with non-admin callers by defaulting `include_hidden` to false when not provided.

### Testing
- Ran `php -l web/search.php` with no syntax errors reported.
- Ran `node --check web/js/songbook.js` with no syntax errors reported.
- Ran `git diff --check` to ensure no whitespace or diff issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed4b87b248322abd143e0e03ef1a1)