### PR TITLE
Add VIP access for hidden song search

### DIFF
--- a/web/search.php
+++ b/web/search.php
@@ -8,6 +8,12 @@ require_once "db_config.php";
 // Get query
 $query = isset ( $_GET ['q'] ) ? trim ( $_GET ['q'] ) : "";
 $includeHidden = filter_var ( $_POST ['include_hidden'] ?? false, FILTER_VALIDATE_BOOLEAN );
+
+if (! $includeHidden && isset ( $_COOKIE [session_name ()] )) {
+	session_start ();
+	$includeHidden = ! empty ( $_SESSION ['include_hidden_search'] );
+}
+
 $applyIdFilter = ! $includeHidden;
 
 // Use regex to check if query is a valid ID (numeric OR numeric + single letter)

--- a/web/vip/.htaccess
+++ b/web/vip/.htaccess
@@ -1,0 +1,6 @@
+AuthType Basic
+AuthName "Heilsame Lieder VIP"
+AuthUserFile /mnt/web406/d1/55/592655/htdocs/heilsame-lieder/admin/.htpasswd
+Require valid-user
+
+DirectoryIndex index.php

--- a/web/vip/index.php
+++ b/web/vip/index.php
@@ -1,0 +1,22 @@
+<?php
+session_set_cookie_params ( [
+	'path' => '/',
+	'httponly' => true,
+	'samesite' => 'Lax'
+] );
+session_start ();
+
+$_SESSION ['include_hidden_search'] = true;
+if (isset ( $_SERVER ['REMOTE_USER'] )) {
+	$_SESSION ['vip_user'] = $_SERVER ['REMOTE_USER'];
+}
+
+$targetUrl = '/';
+if (isset ( $_GET ['q'] ) && trim ( $_GET ['q'] ) !== '') {
+	$targetUrl .= '?q=' . rawurlencode ( trim ( $_GET ['q'] ) );
+}
+
+header ( 'Cache-Control: no-store' );
+header ( 'Location: ' . $targetUrl, true, 302 );
+exit;
+?>


### PR DESCRIPTION
### Motivation
- Provide a non-duplicating way for VIP users to perform searches that include hidden songs by authenticating at a special URL and then returning to the main page with the adjusted search behavior.
- Reuse existing admin credentials for VIP access to avoid managing another password store.
- Keep the public UI identical while enabling the server search endpoint to honor a VIP session flag.

### Description
- Added `web/vip/.htaccess` to protect the `/vip` entry with Basic Auth pointing at the existing admin `.htpasswd` file.
- Added `web/vip/index.php` which sets secure session cookie parameters, writes `$_SESSION['include_hidden_search'] = true`, optionally stores `$_SESSION['vip_user']`, preserves an incoming `?q=` query param, and redirects back to `/` (no page duplication).
- Updated `web/search.php` to, when no POST `include_hidden` is provided, check the session cookie and read `$_SESSION['include_hidden_search']` to decide whether to include hidden songs, preserving the existing POST-based admin override.

### Testing
- Executed `php -l web/search.php` and confirmed there were no syntax errors (success).
- Executed `php -l web/vip/index.php` and confirmed there were no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f05ebe82c832283f93762cb997e85)